### PR TITLE
@toma / @themetalmystic -- Added support for non _id unique indexes and constraint checks

### DIFF
--- a/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryDatabase.java
+++ b/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryDatabase.java
@@ -145,9 +145,13 @@ public class MemoryDatabase extends CommonDatabase {
             boolean ascending = Utils.normalizeValue(key.get("_id")).equals(Double.valueOf(1.0));
             collection.addIndex(new UniqueIndex("_id", ascending));
         } else {
-            // non-id indexes not yet implemented
-            // we can ignore that for a moment since it will not break the
-            // functionality
+            if ((Boolean) indexDescription.get("unique")) {
+                for (Map.Entry<String, Integer> uniqueIndex : ((Map<String, Integer>) indexDescription.get("key")).entrySet()) {
+                    collection.addIndex(new UniqueIndex(uniqueIndex.getKey(), Utils.isTrue(uniqueIndex.getValue())));
+                }
+            } else {
+                // TODO: non-unique non-id indexes not yet implemented
+            }
         }
     }
 

--- a/src/test/java/de/bwaldvogel/MemoryBackendTest.java
+++ b/src/test/java/de/bwaldvogel/MemoryBackendTest.java
@@ -1810,4 +1810,15 @@ public class MemoryBackendTest {
         assertThat(retrievedOid.isNew()).as("retrieved should not be new").isFalse();
     }
 
+    @Test(expected = DuplicateKey.class)
+    public void testInsertWithNonIdIndexesThrowsException() {
+        Map<String, Object> keys = new HashMap<String, Object>() {{
+            put("uniqueKeyField", 1);
+        }};
+        collection.ensureIndex(new BasicDBObject(keys), "unique_key", true);
+
+        collection.insert(json("uniqueKeyField: 'abc', afield: 'avalue'"));
+        collection.insert(json("uniqueKeyField: 'abc', afield: 'avalue'"));
+    }
+
 }


### PR DESCRIPTION
We needed the functionality of a non _id field unique index in the server so we added the code to support it and an accompanying test.
