### PR TITLE
add lexicographic byte array comparison (0x00 < 0xFF) to ValueComparator

### DIFF
--- a/core/src/test/java/de/bwaldvogel/mongo/backend/ValueComparatorTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/ValueComparatorTest.java
@@ -78,4 +78,13 @@ public class ValueComparatorTest {
         assertThat(comparator.compare(new Date(), null)).isGreaterThan(0);
     }
 
+    @Test
+    public void testCompareByteArrayValues() {
+        assertThat(comparator.compare(new byte[]{1}, new byte[]{1})).isEqualTo(0);
+        assertThat(comparator.compare(new byte[]{1}, new byte[]{1,2})).isLessThan(0);
+        assertThat(comparator.compare(new byte[]{0x00}, new byte[]{(byte)0xFF})).isLessThan(0);
+        assertThat(comparator.compare(null, new byte[]{1})).isLessThan(0);
+        assertThat(comparator.compare(new byte[]{1}, null)).isGreaterThan(0);
+    }
+
 }


### PR DESCRIPTION
Hello,

First of all, I'd like to thank you for your work!

I use binary _id in my MongoDB project and when I tried to use the MongoServer with MemoryBackend, collection.find() failed with the UnsupportedOperationException because byte array is not supported in ValueComparator.

I'd like to propose my little change to ValueComparator. I've tested it with my code and it works.

Please let me know what you think.

Regards,
Uri