### PR TITLE
Add support of the $lookup aggregation stage

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoDatabase.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoDatabase.java
@@ -1,36 +1,10 @@
 package de.bwaldvogel.mongo.backend;
 
-import static de.bwaldvogel.mongo.backend.Constants.ID_FIELD;
-
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Iterator;
-import java.util.LinkedHashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import de.bwaldvogel.mongo.MongoBackend;
 import de.bwaldvogel.mongo.MongoCollection;
 import de.bwaldvogel.mongo.MongoDatabase;
 import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
-import de.bwaldvogel.mongo.backend.aggregation.stage.AddFieldsStage;
-import de.bwaldvogel.mongo.backend.aggregation.stage.GroupStage;
-import de.bwaldvogel.mongo.backend.aggregation.stage.LimitStage;
-import de.bwaldvogel.mongo.backend.aggregation.stage.MatchStage;
-import de.bwaldvogel.mongo.backend.aggregation.stage.OrderByStage;
-import de.bwaldvogel.mongo.backend.aggregation.stage.ProjectStage;
-import de.bwaldvogel.mongo.backend.aggregation.stage.SkipStage;
-import de.bwaldvogel.mongo.backend.aggregation.stage.UnwindStage;
+import de.bwaldvogel.mongo.backend.aggregation.stage.*;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.exception.MongoServerError;
 import de.bwaldvogel.mongo.exception.MongoServerException;
@@ -41,6 +15,16 @@ import de.bwaldvogel.mongo.wire.message.MongoInsert;
 import de.bwaldvogel.mongo.wire.message.MongoQuery;
 import de.bwaldvogel.mongo.wire.message.MongoUpdate;
 import io.netty.channel.Channel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+
+import static de.bwaldvogel.mongo.backend.Constants.ID_FIELD;
 
 public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
 
@@ -182,9 +166,9 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
             collectionDescription.put("info", new Document("readOnly", false));
             collectionDescription.put("type", "collection");
             collectionDescription.put("idIndex", new Document("key", new Document(ID_FIELD, 1))
-                .append("name", "_id_")
-                .append("ns", namespace)
-                .append("v", 2)
+                    .append("name", "_id_")
+                    .append("ns", namespace)
+                    .append("v", 2)
             );
             firstBatch.add(collectionDescription);
         }
@@ -194,8 +178,8 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
 
     private Document listIndexes() {
         Iterable<Document> indexes = Optional.ofNullable(resolveCollection(INDEXES_COLLECTION_NAME, false))
-            .map(MongoCollection::queryAll)
-            .orElse(Collections.emptyList());
+                .map(MongoCollection::queryAll)
+                .orElse(Collections.emptyList());
         return Utils.cursorResponse(getDatabaseName() + ".$cmd.listIndexes", indexes);
     }
 
@@ -353,7 +337,7 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
         MongoCollection<P> collection = resolveCollection(collectionName, false);
         if (collection != null) {
             throw new MongoServerError(48, "NamespaceExists",
-                "a collection '" + getDatabaseName() + "." + collectionName + "' already exists");
+                    "a collection '" + getDatabaseName() + "." + collectionName + "' already exists");
         }
 
         createCollection(collectionName);
@@ -366,8 +350,7 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
     private Document commandCreateIndexes(Document query) {
         int indexesBefore = countIndexes();
 
-        @SuppressWarnings("unchecked")
-        final Collection<Document> indexDescriptions = (Collection<Document>) query.get("indexes");
+        @SuppressWarnings("unchecked") final Collection<Document> indexDescriptions = (Collection<Document>) query.get("indexes");
         for (Document indexDescription : indexDescriptions) {
             addIndex(indexDescription);
         }
@@ -395,8 +378,8 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
 
     private Collection<MongoCollection<P>> collections() {
         return collections.values().stream()
-            .filter(collection -> !collection.getCollectionName().startsWith("system."))
-            .collect(Collectors.toCollection(LinkedHashSet::new));
+                .filter(collection -> !collection.getCollectionName().startsWith("system."))
+                .collect(Collectors.toCollection(LinkedHashSet::new));
     }
 
     private Document commandDatabaseStats() {
@@ -615,6 +598,10 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
                     String unwindField = (String) stage.get(stageOperation);
                     aggregation.addStage(new UnwindStage(unwindField));
                     break;
+                case "$lookup":
+                    Document lookup = (Document) stage.get(stageOperation);
+                    aggregation.addStage(new LookupStage(lookup, this));
+                    break;
                 default:
                     throw new MongoServerError(40324, "Unrecognized pipeline stage name: '" + stageOperation + "'");
             }
@@ -823,7 +810,7 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
         try {
             if (collectionName.startsWith("system.")) {
                 throw new MongoServerError(73, "InvalidNamespace",
-                    "cannot write to '" + getDatabaseName() + "." + collectionName + "'");
+                        "cannot write to '" + getDatabaseName() + "." + collectionName + "'");
             }
             MongoCollection<P> collection = resolveCollection(collectionName, false);
             final int n;

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStage.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStage.java
@@ -1,0 +1,98 @@
+package de.bwaldvogel.mongo.backend.aggregation.stage;
+
+import de.bwaldvogel.mongo.MongoCollection;
+import de.bwaldvogel.mongo.MongoDatabase;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.exception.MongoServerError;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+import static java.util.stream.Collectors.toList;
+
+public class LookupStage implements AggregationStage {
+    private static final String FROM = "from";
+    private static final String LOCAL_FIELD = "localField";
+    private static final String FOREIGN_FIELD = "foreignField";
+    private static final String AS = "as";
+    private static final Set<String> CONFIGURATION_KEYS;
+    private final String localField;
+    private final String foreignField;
+    private final String as;
+    private final MongoCollection<?> collection;
+
+    static {
+        CONFIGURATION_KEYS = new HashSet<>();
+        CONFIGURATION_KEYS.add(FROM);
+        CONFIGURATION_KEYS.add(LOCAL_FIELD);
+        CONFIGURATION_KEYS.add(FOREIGN_FIELD);
+        CONFIGURATION_KEYS.add(AS);
+    }
+
+    public LookupStage(Document configuration, MongoDatabase mongoDatabase) {
+        String from = readConfigurationProperty(configuration, FROM);
+        collection = mongoDatabase.resolveCollection(from, false);
+        localField = readConfigurationProperty(configuration, LOCAL_FIELD);
+        foreignField = readConfigurationProperty(configuration, FOREIGN_FIELD);
+        as = readConfigurationProperty(configuration, AS);
+        ensureAllConfigurationPropertiesExist(configuration);
+    }
+
+    private String readConfigurationProperty(Document configuration, String name) {
+        Object value = configuration.get(name);
+        if (value == null) {
+            throw buildConfigurationError("missing '" + name + "' option to $lookup stage specification: " + configuration);
+        }
+        if (value instanceof String) {
+            return (String) value;
+        }
+        throw buildConfigurationError("'" + name + "' option to $lookup must be a string, but was type " +
+                value.getClass().getName());
+    }
+
+    private void ensureAllConfigurationPropertiesExist(Document configuration) {
+        for (String name : configuration.keySet()) {
+            if (!CONFIGURATION_KEYS.contains(name)) {
+                String message = "unknown argument to $lookup: " + name;
+                throw buildConfigurationError(message);
+            }
+        }
+    }
+
+    private MongoServerError buildConfigurationError(String message) {
+        return new MongoServerError(9, "FailedToParse", message);
+    }
+
+    @Override
+    public Stream<Document> apply(Stream<Document> stream) {
+        return stream.map(this::resolveRemoteField)
+                .filter(Objects::nonNull);
+    }
+
+    private Document resolveRemoteField(Document document) {
+        Object value = document.get(localField);
+        List<Document> documents = lookupValue(value);
+        if (documents.isEmpty()) {
+            return null;
+        }
+        Document result = document.clone();
+        result.put(as, documents);
+        return result;
+    }
+
+    private List<Document> lookupValue(Object value) {
+        if (value instanceof List) {
+            return ((List<?>) value).stream()
+                    .flatMap(item -> lookupValue(item).stream())
+                    .collect(toList());
+        }
+        Document query = new Document().append(foreignField, value);
+        Iterable<Document> queryResult = collection.handleQuery(query);
+        return StreamSupport.stream(queryResult.spliterator(), false)
+                .collect(toList());
+    }
+}

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStageTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStageTest.java
@@ -1,0 +1,145 @@
+package de.bwaldvogel.mongo.backend.aggregation.stage;
+
+import de.bwaldvogel.mongo.MongoCollection;
+import de.bwaldvogel.mongo.MongoDatabase;
+import de.bwaldvogel.mongo.TestUtils;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.exception.MongoServerException;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.stream.Stream;
+
+import static de.bwaldvogel.mongo.TestUtils.json;
+import static java.util.stream.Collectors.toList;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LookupStageTest {
+    private MongoDatabase database;
+    private MongoCollection authorsCollection;
+
+    @Before
+    public void setUp() {
+        database = mock(MongoDatabase.class);
+        authorsCollection = mock(MongoCollection.class);
+        when(database.resolveCollection("authors", false)).thenReturn(authorsCollection);
+    }
+
+    @Test
+    public void testMissingFromField() {
+        assertThatThrownBy(() -> buildLookupStage("localField: 'authorId', foreignField: '_id', as: 'author'"))
+                .isInstanceOf(MongoServerException.class)
+                .hasMessage("[Error 9] missing 'from' option to $lookup stage specification: " +
+                        "{\"localField\" : \"authorId\", \"foreignField\" : \"_id\", \"as\" : \"author\"}");
+    }
+
+    @Test
+    public void testMissingLocalFieldField() {
+        assertThatThrownBy(() -> buildLookupStage("from: 'authors', foreignField: '_id', as: 'author'"))
+                .isInstanceOf(MongoServerException.class)
+                .hasMessage("[Error 9] missing 'localField' option to $lookup stage specification: " +
+                        "{\"from\" : \"authors\", \"foreignField\" : \"_id\", \"as\" : \"author\"}");
+    }
+
+    @Test
+    public void testMissingForeignFieldField() {
+        assertThatThrownBy(() -> buildLookupStage("from: 'authors', localField: 'authorId', as: 'author'"))
+                .isInstanceOf(MongoServerException.class)
+                .hasMessage("[Error 9] missing 'foreignField' option to $lookup stage specification: " +
+                        "{\"from\" : \"authors\", \"localField\" : \"authorId\", \"as\" : \"author\"}");
+    }
+
+    @Test
+    public void testMissingAsField() {
+        assertThatThrownBy(() -> buildLookupStage("from: 'authors', localField: 'authorId', foreignField: '_id'"))
+                .isInstanceOf(MongoServerException.class)
+                .hasMessage("[Error 9] missing 'as' option to $lookup stage specification: " +
+                        "{\"from\" : \"authors\", \"localField\" : \"authorId\", \"foreignField\" : \"_id\"}");
+    }
+
+    @Test
+    public void testFromFieldWithWrongType() {
+        assertThatThrownBy(() -> buildLookupStage("from: 1, localField: 'authorId', foreignField: '_id', as: 'author'"))
+                .isInstanceOf(MongoServerException.class)
+                .hasMessage("[Error 9] 'from' option to $lookup must be a string, but was type java.lang.Integer");
+    }
+
+    @Test
+    public void testUnexpectedConfigurationField() {
+        assertThatThrownBy(() -> buildLookupStage("from: 'authors', localField: 'authorId', foreignField: '_id', as: 'author', unknown: 'hello'"))
+                .isInstanceOf(MongoServerException.class)
+                .hasMessage("[Error 9] unknown argument to $lookup: unknown");
+    }
+
+    @Test
+    public void testLookupObjectThatExists() {
+        LookupStage lookupStage = buildLookupStage("from: 'authors', 'localField': 'authorId', foreignField: '_id', as: 'author'");
+        configureAuthorsCollection("_id: 3", "_id: 3, name: 'Uncle Bob'");
+        Document document = json("title: 'Clean Code', authorId: 3");
+
+        Stream<Document> result = lookupStage.apply(Stream.of(document));
+
+        assertThat(result).containsOnly(
+                json("title: 'Clean Code', authorId: 3, author: [{_id: 3, name: 'Uncle Bob'}]")
+        );
+    }
+
+    @Test
+    public void testLookupObjectThatExistsMultipleTimes() {
+        LookupStage lookupStage = buildLookupStage("from: 'authors', 'localField': 'job', foreignField: 'job', as: 'seeAuthors'");
+        configureAuthorsCollection("job: 'Developer'",
+                "_id: 3, name: 'Uncle Bob', job: 'Developer'",
+                "_id: 5, name: 'Alice', job: 'Developer'");
+        Document document = json("_id: 1, title: 'Developing for dummies', job: 'Developer'");
+
+        Stream<Document> result = lookupStage.apply(Stream.of(document));
+
+        assertThat(result).containsOnly(
+                json("_id: 1, title: 'Developing for dummies', job: 'Developer', " +
+                        "seeAuthors: [{_id: 3, name: 'Uncle Bob', job: 'Developer'}, {_id: 5, name: 'Alice', job: 'Developer'}]")
+        );
+    }
+
+    @Test
+    public void testLookupObjectThatDoesNotExist() {
+        LookupStage lookupStage = buildLookupStage("from: 'authors', 'localField': 'job', foreignField: 'job', as: 'seeAuthors'");
+        configureAuthorsCollection("job: 'Developer'");
+        Document document = json("_id: 1, title: 'Developing for dummies', job: 'Developer'");
+
+        Stream<Document> result = lookupStage.apply(Stream.of(document));
+
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    public void testLookupObjectBasedOnAnArrayKey() {
+        LookupStage lookupStage = buildLookupStage("from: 'authors', 'localField': 'authorsIds', foreignField: '_id', as: 'authors'");
+        configureAuthorsCollection("_id: 3", "_id: 3, name: 'Uncle Bob'");
+        configureAuthorsCollection("_id: 20", "_id: 20, name: 'Martin Fowler'");
+        Document document1 = json("title: 'Agile Manifesto', authorsIds: [3, 20, 22]");
+        Document document2 = json("title: 'Clean Code', authorsIds: [3]");
+
+        Stream<Document> result = lookupStage.apply(Stream.of(document1, document2));
+
+        assertThat(result).containsOnly(
+                json("title: 'Agile Manifesto', authorsIds: [3, 20, 22], authors: [{_id: 3, name: 'Uncle Bob'}, {_id: 20, name: 'Martin Fowler'}]"),
+                json("title: 'Clean Code', authorsIds: [3], authors: [{_id: 3, name: 'Uncle Bob'}]")
+        );
+    }
+
+    private LookupStage buildLookupStage(String jsonDocument) {
+        return new LookupStage(json(jsonDocument), database);
+    }
+
+    private void configureAuthorsCollection(String expectedJsonQuery, String... authors) {
+        List<Document> documents = Stream.of(authors)
+                .map(TestUtils::json)
+                .collect(toList());
+        when(authorsCollection.handleQuery(json(expectedJsonQuery)))
+                .thenReturn(documents);
+    }
+}

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractAggregationTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractAggregationTest.java
@@ -1,9 +1,10 @@
 package de.bwaldvogel.mongo.backend;
 
-import static de.bwaldvogel.mongo.backend.TestUtils.json;
-import static de.bwaldvogel.mongo.backend.TestUtils.toArray;
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import com.mongodb.MongoCommandException;
+import com.mongodb.client.MongoCollection;
+import org.bson.Document;
+import org.bson.types.ObjectId;
+import org.junit.Test;
 
 import java.time.Instant;
 import java.util.Arrays;
@@ -11,11 +12,10 @@ import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 
-import org.bson.Document;
-import org.bson.types.ObjectId;
-import org.junit.Test;
-
-import com.mongodb.MongoCommandException;
+import static de.bwaldvogel.mongo.backend.TestUtils.json;
+import static de.bwaldvogel.mongo.backend.TestUtils.toArray;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 public abstract class AbstractAggregationTest extends AbstractTest {
 
@@ -24,8 +24,8 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         List<Document> pipeline = Collections.singletonList(json("$unknown: {}"));
 
         assertThatExceptionOfType(MongoCommandException.class)
-            .isThrownBy(() -> collection.aggregate(pipeline).first())
-            .withMessageContaining("Command failed with error 40324: 'Unrecognized pipeline stage name: '$unknown'");
+                .isThrownBy(() -> collection.aggregate(pipeline).first())
+                .withMessageContaining("Command failed with error 40324: 'Unrecognized pipeline stage name: '$unknown'");
     }
 
     @Test
@@ -33,15 +33,15 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         List<Document> pipeline = Collections.singletonList(json("$unknown: {}, bar: 1"));
 
         assertThatExceptionOfType(MongoCommandException.class)
-            .isThrownBy(() -> collection.aggregate(pipeline).first())
-            .withMessageContaining("Command failed with error 40323: 'A pipeline stage specification object must contain exactly one field.'");
+                .isThrownBy(() -> collection.aggregate(pipeline).first())
+                .withMessageContaining("Command failed with error 40323: 'A pipeline stage specification object must contain exactly one field.'");
     }
 
     @Test
     public void testAggregateWithMissingCursor() throws Exception {
         assertThatExceptionOfType(MongoCommandException.class)
-            .isThrownBy(() -> db.runCommand(json("aggregate: 'collection', pipeline: [{$match: {}}]")))
-            .withMessageContaining("Command failed with error 9: 'The 'cursor' option is required, except for aggregate with the explain argument'");
+                .isThrownBy(() -> db.runCommand(json("aggregate: 'collection', pipeline: [{$match: {}}]")))
+                .withMessageContaining("Command failed with error 9: 'The 'cursor' option is required, except for aggregate with the explain argument'");
     }
 
     @Test
@@ -57,7 +57,7 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 4, a: {value: 5}"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, n:4, sumOfA: 45, sumOfB: 31.5"));
+                .containsExactly(json("_id: null, n:4, sumOfA: 45, sumOfB: 31.5"));
     }
 
     @Test
@@ -73,7 +73,7 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 4, c: 'aaa'"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, minA: 15, maxB: 20, minC: 1.0, maxC: 'zzz'"));
+                .containsExactly(json("_id: null, minA: 15, maxB: 20, minC: 1.0, maxC: 'zzz'"));
     }
 
     @Test
@@ -87,7 +87,7 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 2, a: 15, b: {value: 10}"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, minOfA: null, maxOfB: null"));
+                .containsExactly(json("_id: null, minOfA: null, maxOfB: null"));
     }
 
     @Test
@@ -96,8 +96,8 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         List<Document> pipeline = Collections.singletonList(new Document("$group", query));
 
         assertThatExceptionOfType(MongoCommandException.class)
-            .isThrownBy(() -> collection.aggregate(pipeline).first())
-            .withMessageContaining("Command failed with error 15952: 'unknown group operator '$foo''");
+                .isThrownBy(() -> collection.aggregate(pipeline).first())
+                .withMessageContaining("Command failed with error 15952: 'unknown group operator '$foo''");
     }
 
     @Test
@@ -106,8 +106,8 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         List<Document> pipeline = Collections.singletonList(new Document("$group", query));
 
         assertThatExceptionOfType(MongoCommandException.class)
-            .isThrownBy(() -> collection.aggregate(pipeline).first())
-            .withMessageContaining("Command failed with error 40238: 'The field 'n' must specify one accumulator'");
+                .isThrownBy(() -> collection.aggregate(pipeline).first())
+                .withMessageContaining("Command failed with error 40238: 'The field 'n' must specify one accumulator'");
     }
 
     @Test
@@ -118,7 +118,7 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 2"));
 
         assertThat(toArray(collection.aggregate(Collections.emptyList())))
-            .containsExactly(json("_id: 1"), json("_id: 2"));
+                .containsExactly(json("_id: 1"), json("_id: 2"));
     }
 
     @Test
@@ -126,8 +126,8 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         List<Document> pipeline = Collections.singletonList(new Document("$group", json("n: {$sum: 1}")));
 
         assertThatExceptionOfType(MongoCommandException.class)
-            .isThrownBy(() -> toArray(collection.aggregate(pipeline)))
-            .withMessageContaining("Command failed with error 15955: 'a group specification must include an _id'");
+                .isThrownBy(() -> toArray(collection.aggregate(pipeline)))
+                .withMessageContaining("Command failed with error 15955: 'a group specification must include an _id'");
     }
 
     @Test
@@ -141,32 +141,32 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 2"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, n: 2"));
+                .containsExactly(json("_id: null, n: 2"));
 
         query.putAll(json("n: {$sum: 'abc'}"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, n: 0"));
+                .containsExactly(json("_id: null, n: 0"));
 
         query.putAll(json("n: {$sum: 2}"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, n: 4"));
+                .containsExactly(json("_id: null, n: 4"));
 
         query.putAll(json("n: {$sum: 1.75}"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, n: 3.5"));
+                .containsExactly(json("_id: null, n: 3.5"));
 
         query.putAll(new Document("n", new Document("$sum", 10000000000L)));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, n: 20000000000"));
+                .containsExactly(json("_id: null, n: 20000000000"));
 
         query.putAll(new Document("n", new Document("$sum", -2.5F)));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, n: -5.0"));
+                .containsExactly(json("_id: null, n: -5.0"));
     }
 
     @Test
@@ -180,12 +180,12 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 2, a: 3.0, b: 'aaa'"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, avg: 1.0"));
+                .containsExactly(json("_id: null, avg: 1.0"));
 
         query.putAll(json("avg: {$avg: '$a'}, avgB: {$avg: '$b'}"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, avg: 4.5, avgB: null"));
+                .containsExactly(json("_id: null, avg: 4.5, avgB: null"));
     }
 
     @Test
@@ -202,12 +202,12 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 6, a: 7, c: 'a'"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1, count: 2, avg: null"),
-                json("_id: 2, count: 2, avg: 3.5"),
-                json("_id: 5, count: 1, avg: 10.0"),
-                json("_id: 7, count: 1, avg: null")
-            );
+                .containsExactly(
+                        json("_id: 1, count: 2, avg: null"),
+                        json("_id: 2, count: 2, avg: 3.5"),
+                        json("_id: 5, count: 1, avg: 10.0"),
+                        json("_id: 7, count: 1, avg: null")
+                );
     }
 
     @Test
@@ -223,10 +223,10 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 4, value: 2"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1.0, count: 2"),
-                json("_id: 2.0, count: 2")
-            );
+                .containsExactly(
+                        json("_id: 1.0, count: 2"),
+                        json("_id: 2.0, count: 2")
+                );
     }
 
     @Test
@@ -243,13 +243,13 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 5, value: 2, start: 6, end: 7"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: {abs: NaN, sum: null}, count: 1"),
-                json("_id: {abs: 1.0, sum: 3}, count: 1"),
-                json("_id: {abs: 1.0, sum: 0}, count: 1"),
-                json("_id: {abs: 2.0, sum: -2}, count: 1"),
-                json("_id: {abs: 2.0, sum: 1}, count: 1")
-            );
+                .containsExactly(
+                        json("_id: {abs: NaN, sum: null}, count: 1"),
+                        json("_id: {abs: 1.0, sum: 3}, count: 1"),
+                        json("_id: {abs: 1.0, sum: 0}, count: 1"),
+                        json("_id: {abs: 2.0, sum: -2}, count: 1"),
+                        json("_id: {abs: 2.0, sum: 1}, count: 1")
+                );
     }
 
     @Test
@@ -266,11 +266,11 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 5, item: 'xyz', price:  5, quantity: 10").append("date", date("2014-02-15T09:12:00Z")));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: { day:  1, year: 2014 }, itemsSold: [ 'abc' ]"),
-                json("_id: { day: 34, year: 2014 }, itemsSold: [ 'jkl', 'xyz' ]"),
-                json("_id: { day: 46, year: 2014 }, itemsSold: [ 'abc', 'xyz' ]")
-            );
+                .containsExactly(
+                        json("_id: { day:  1, year: 2014 }, itemsSold: [ 'abc' ]"),
+                        json("_id: { day: 34, year: 2014 }, itemsSold: [ 'jkl', 'xyz' ]"),
+                        json("_id: { day: 46, year: 2014 }, itemsSold: [ 'abc', 'xyz' ]")
+                );
     }
 
     @Test
@@ -285,7 +285,7 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 3"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: 1, set: [ ]"));
+                .containsExactly(json("_id: 1, set: [ ]"));
     }
 
     @Test
@@ -300,11 +300,11 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 3, item: 'xyz', price: 5, fee: 0"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1, item: 'abc', total: 12"),
-                json("_id: 2, item: 'jkl', total: 21"),
-                json("_id: 3, item: 'xyz', total: 5 ")
-            );
+                .containsExactly(
+                        json("_id: 1, item: 'abc', total: 12"),
+                        json("_id: 2, item: 'jkl', total: 21"),
+                        json("_id: 3, item: 'xyz', total: 5 ")
+                );
     }
 
     @Test
@@ -319,11 +319,11 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 3, price: 10, fee: 0"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 2, price: 20, fee: 0"),
-                json("_id: 3, price: 10, fee: 0"),
-                json("_id: 1, price: 10, fee: 1")
-            );
+                .containsExactly(
+                        json("_id: 2, price: 20, fee: 0"),
+                        json("_id: 3, price: 10, fee: 0"),
+                        json("_id: 1, price: 10, fee: 1")
+                );
     }
 
     @Test
@@ -338,11 +338,11 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 3, x: 30, foo: {bar: 7.3}"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1, value: 10, other: null"),
-                json("_id: 2, value: 20, other: null"),
-                json("_id: 3, value: 30, n: 7.3, other: null")
-            );
+                .containsExactly(
+                        json("_id: 1, value: 10, other: null"),
+                        json("_id: 2, value: 20, other: null"),
+                        json("_id: 3, value: 30, n: 7.3, other: null")
+                );
     }
 
     @Test
@@ -355,7 +355,7 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(new Document("_id", new ObjectId("abcd01234567890123456789")));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("idHex: 'abcd01234567890123456789'"));
+                .containsExactly(json("idHex: 'abcd01234567890123456789'"));
     }
 
     @Test
@@ -370,11 +370,11 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 3, value: 123"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1, x: 10, value: 10"),
-                json("_id: 2"),
-                json("_id: 3")
-            );
+                .containsExactly(
+                        json("_id: 1, x: 10, value: 10"),
+                        json("_id: 2"),
+                        json("_id: 3")
+                );
     }
 
     @Test
@@ -391,10 +391,10 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 4, price: 10, quality: 5"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1, price: 10, quality: 50"),
-                json("_id: 3, price: 50, quality: 150")
-            );
+                .containsExactly(
+                        json("_id: 1, price: 10, quality: 50"),
+                        json("_id: 3, price: 50, quality: 150")
+                );
     }
 
     @Test
@@ -410,10 +410,10 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 4, value: -5.34"));
 
         assertThat(toArray(collection.aggregate(pipeline))).containsExactly(
-            json("_id: 1, value: 9.25, ceilingValue: 10"),
-            json("_id: 2, value: 8.73, ceilingValue: 9"),
-            json("_id: 3, value: 4.32, ceilingValue: 5"),
-            json("_id: 4, value: -5.34, ceilingValue: -5")
+                json("_id: 1, value: 9.25, ceilingValue: 10"),
+                json("_id: 2, value: 8.73, ceilingValue: 9"),
+                json("_id: 3, value: 4.32, ceilingValue: 5"),
+                json("_id: 4, value: -5.34, ceilingValue: -5")
         );
     }
 
@@ -450,11 +450,11 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 5, item: 'xyz', price:  5, quantity: 10").append("date", date("2014-02-15T09:12:00Z")));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 'abc'").append("firstSale", date("2014-01-01T08:00:00Z")).append("lastSale", date("2014-02-15T08:00:00Z")),
-                json("_id: 'jkl'").append("firstSale", date("2014-02-03T09:00:00Z")).append("lastSale", date("2014-02-03T09:00:00Z")),
-                json("_id: 'xyz'").append("firstSale", date("2014-02-03T09:05:00Z")).append("lastSale", date("2014-02-15T09:12:00Z"))
-            );
+                .containsExactly(
+                        json("_id: 'abc'").append("firstSale", date("2014-01-01T08:00:00Z")).append("lastSale", date("2014-02-15T08:00:00Z")),
+                        json("_id: 'jkl'").append("firstSale", date("2014-02-03T09:00:00Z")).append("lastSale", date("2014-02-03T09:00:00Z")),
+                        json("_id: 'xyz'").append("firstSale", date("2014-02-03T09:05:00Z")).append("lastSale", date("2014-02-15T09:12:00Z"))
+                );
     }
 
     @Test
@@ -468,7 +468,7 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 2, a: 20, b: 0.2"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("_id: null, a: [10, 20], b: [{v: 0.1}, {v: 0.2}], c: []"));
+                .containsExactly(json("_id: null, a: [10, 20], b: [{v: 0.1}, {v: 0.2}], c: []"));
     }
 
     @Test
@@ -479,8 +479,8 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 1"));
 
         assertThatExceptionOfType(MongoCommandException.class)
-            .isThrownBy(() -> collection.aggregate(pipeline).first())
-            .withMessageContaining("Command failed with error 17276: 'Use of undefined variable: UNDEFINED'");
+                .isThrownBy(() -> collection.aggregate(pipeline).first())
+                .withMessageContaining("Command failed with error 17276: 'Use of undefined variable: UNDEFINED'");
     }
 
     // https://github.com/bwaldvogel/mongo-java-server/issues/31
@@ -494,7 +494,7 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 1, a: {v: 10}"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(json("doc: {_id: 1, a: {v: 10}}, a: {v: 10}, a_v: 10"));
+                .containsExactly(json("doc: {_id: 1, a: {v: 10}}, a: {v: 10}, a_v: 10"));
     }
 
     @Test
@@ -508,10 +508,10 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 2, a: [1], b: [3, 2]"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1, all: null"),
-                json("_id: 2, all: [1, 3, 2]")
-            );
+                .containsExactly(
+                        json("_id: 1, all: null"),
+                        json("_id: 2, all: [1, 3, 2]")
+                );
     }
 
     @Test
@@ -525,10 +525,10 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 2, name: 'second document'"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1, names: ['first', 'document']"),
-                json("_id: 2, names: ['second', 'document']")
-            );
+                .containsExactly(
+                        json("_id: 1, names: ['first', 'document']"),
+                        json("_id: 2, names: ['second', 'document']")
+                );
     }
 
     @Test
@@ -540,11 +540,33 @@ public abstract class AbstractAggregationTest extends AbstractTest {
         collection.insertOne(json("_id: 1, item: 'ABC1', sizes: ['S', 'M', 'L']"));
 
         assertThat(toArray(collection.aggregate(pipeline)))
-            .containsExactly(
-                json("_id: 1, item: 'ABC1', sizes: 'S'"),
-                json("_id: 1, item: 'ABC1', sizes: 'M'"),
-                json("_id: 1, item: 'ABC1', sizes: 'L'")
-            );
+                .containsExactly(
+                        json("_id: 1, item: 'ABC1', sizes: 'S'"),
+                        json("_id: 1, item: 'ABC1', sizes: 'M'"),
+                        json("_id: 1, item: 'ABC1', sizes: 'L'")
+                );
+    }
+
+    @Test
+    public void testAggregateWithLookup() {
+        MongoCollection<Document> authorsCollection = db.getCollection("authors");
+        authorsCollection.insertOne(json("_id: 1, name: 'Uncle Bob'"));
+        authorsCollection.insertOne(json("_id: 2, name: 'Martin Fowler'"));
+        Document lookup = json("$lookup: {from: 'authors', localField: 'authorId', foreignField: '_id', as: 'author'}");
+        List<Document> pipeline = Collections.singletonList(lookup);
+
+        assertThat(collection.aggregate(pipeline)).isEmpty();
+
+        collection.insertOne(json("_id: 1, title: 'Refactoring', authorId: 2"));
+        collection.insertOne(json("_id: 2, title: 'Clean Code', authorId: 1"));
+        collection.insertOne(json("_id: 3, title: 'Clean Coder', authorId: 1"));
+
+        assertThat(collection.aggregate(pipeline))
+                .containsOnly(
+                        json("_id: 1, title: 'Refactoring', authorId: 2, author: [{_id: 2, name: 'Martin Fowler'}]"),
+                        json("_id: 2, title: 'Clean Code', authorId: 1, author: [{_id: 1, name: 'Uncle Bob'}]"),
+                        json("_id: 3, title: 'Clean Coder', authorId: 1, author: [{_id: 1, name: 'Uncle Bob'}]")
+                );
     }
 
     private static Date date(String instant) {


### PR DESCRIPTION
This pull request adds basic support of the [`$lookup` aggregation stage](https://docs.mongodb.com/manual/reference/operator/aggregation/lookup/).

It supports only what MongoDB 3.2 supported. It means that the `let` / `pipeline` usage is not supported.