### PR TITLE
Add support to $replaceRoot aggregation stage

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoDatabase.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoDatabase.java
@@ -30,6 +30,7 @@ import de.bwaldvogel.mongo.backend.aggregation.stage.LookupStage;
 import de.bwaldvogel.mongo.backend.aggregation.stage.MatchStage;
 import de.bwaldvogel.mongo.backend.aggregation.stage.OrderByStage;
 import de.bwaldvogel.mongo.backend.aggregation.stage.ProjectStage;
+import de.bwaldvogel.mongo.backend.aggregation.stage.ReplaceRootStage;
 import de.bwaldvogel.mongo.backend.aggregation.stage.SkipStage;
 import de.bwaldvogel.mongo.backend.aggregation.stage.UnwindStage;
 import de.bwaldvogel.mongo.bson.Document;
@@ -619,6 +620,10 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
                 case "$lookup":
                     Document lookup = (Document) stage.get(stageOperation);
                     aggregation.addStage(new LookupStage(lookup, this));
+                    break;
+                case "$replaceRoot":
+                    Document replaceRoot = (Document) stage.get(stageOperation);
+                    aggregation.addStage(new ReplaceRootStage(replaceRoot));
                     break;
                 default:
                     throw new MongoServerError(40324, "Unrecognized pipeline stage name: '" + stageOperation + "'");

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStage.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStage.java
@@ -27,22 +27,18 @@ public class ReplaceRootStage implements AggregationStage {
     }
 
     Document replaceRoot(Document document) {
-        Object result = Expression.evaluateDocument(newRoot, document);
+        Object evaluatedNewRoot = Expression.evaluateDocument(newRoot, document);
 
-        if (!(result instanceof Document)) {
-            throw typeMismatchError(result, document);
+        if (!(evaluatedNewRoot instanceof Document)) {
+            throw new MongoServerError(40228, "'newRoot' expression must evaluate to an object, but resulting value was: " + toString(evaluatedNewRoot)
+                + ". Type of resulting value: '" + describeType(evaluatedNewRoot)
+                + "'. Input document: " + document.toString(true)); // TODO: Mongo will only show the matched element (if any). How to get it?
         }
 
-        return (Document) result;
+        return (Document) evaluatedNewRoot;
     }
 
-    private static MongoServerError typeMismatchError(Object subject, Document document) {
-        return new MongoServerError(40228, "'newRoot' expression must evaluate to an object, but resulting value was: " + serializeType(subject)
-            + ". Type of resulting value: '" + describeType(subject)
-            + "'. Input document: " + document.toString(true)); // TODO: Mongo will only show the matched element (if any). How to get it?
-    }
-
-    private static String serializeType(Object subject) {
+    private static String toString(Object subject) {
         if (Missing.class.isAssignableFrom(subject.getClass())) {
             return "MISSING";
         }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStage.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStage.java
@@ -1,0 +1,55 @@
+package de.bwaldvogel.mongo.backend.aggregation.stage;
+
+import static de.bwaldvogel.mongo.backend.Utils.describeType;
+
+import java.util.stream.Stream;
+
+import de.bwaldvogel.mongo.backend.Missing;
+import de.bwaldvogel.mongo.backend.aggregation.Expression;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.exception.MongoServerError;
+
+public class ReplaceRootStage implements AggregationStage {
+
+    private final Object newRoot;
+
+    public ReplaceRootStage(Document document) {
+        newRoot = document.getOrMissing("newRoot");
+
+        if (Missing.isNullOrMissing(newRoot)) {
+            throw new MongoServerError(40231, "no newRoot specified for the $replaceRoot stage");
+        }
+    }
+
+    @Override
+    public Stream<Document> apply(Stream<Document> stream) {
+        return stream.map(this::replaceRoot);
+    }
+
+    Document replaceRoot(Document document) {
+        Object result = Expression.evaluateDocument(newRoot, document);
+
+        if (!(result instanceof Document)) {
+            throw typeMismatchError(result, document);
+        }
+
+        return (Document) result;
+    }
+
+    private static MongoServerError typeMismatchError(Object subject, Document document) {
+        return new MongoServerError(40228, "'newRoot' expression must evaluate to an object, but resulting value was: " + serializeType(subject)
+            + ". Type of resulting value: '" + describeType(subject)
+            + "'. Input document: " + document.toString(true)); // TODO: Mongo will only show the matched element (if any). How to get it?
+    }
+
+    private static String serializeType(Object subject) {
+        if (Missing.class.isAssignableFrom(subject.getClass())) {
+            return "MISSING";
+        }
+        if (String.class.isAssignableFrom(subject.getClass())) {
+            return "\"" + subject + "\"";
+        }
+        // TODO: how to serialize other types e.g. BIN_DATA?
+        return subject.toString();
+    }
+}

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStageTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStageTest.java
@@ -1,0 +1,45 @@
+package de.bwaldvogel.mongo.backend.aggregation.stage;
+
+import static de.bwaldvogel.mongo.TestUtils.json;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+import org.assertj.core.api.SoftAssertions;
+import org.junit.Test;
+
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.exception.MongoServerError;
+
+public class ReplaceRootStageTest {
+
+    @Test
+    public void testReplaceRoot() throws Exception {
+        assertThat(replaceRoot(json("newRoot: '$a'"), json("a: { b: { c: 1 } }"))).isEqualTo(json("b: { c: 1 }"));
+        assertThat(replaceRoot(json("newRoot: '$a.b'"), json("a: { b: { c: 1 } }"))).isEqualTo(json("c: 1"));
+        assertThat(replaceRoot(json("newRoot: { x: '$a.b' }"), json("a: { b: { c: 1 } }"))).isEqualTo(json("x: { c: 1 }"));
+    }
+
+    private static Document replaceRoot(Document replaceRoot, Document document) {
+        return new ReplaceRootStage(replaceRoot).replaceRoot(document);
+    }
+
+    @Test
+    public void testIllegalReplaceRoot() throws Exception {
+        assertThatExceptionOfType(MongoServerError.class)
+            .isThrownBy(() -> new ReplaceRootStage(json("")))
+            .withMessage("[Error 40231] no newRoot specified for the $replaceRoot stage");
+
+        assertThatExceptionOfType(MongoServerError.class)
+            .isThrownBy(() -> new ReplaceRootStage(json("newRoot: 1")).replaceRoot(json("a: { b: {} }")))
+            .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: 1. Type of resulting value: 'int'. Input document: {a: {b: {}}}");
+
+        assertThatExceptionOfType(MongoServerError.class)
+            .isThrownBy(() -> new ReplaceRootStage(json("newRoot: '$c'")).replaceRoot(json("a: { b: {} }")))
+            .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: MISSING. Type of resulting value: 'missing'. Input document: {a: {b: {}}}");
+
+        assertThatExceptionOfType(MongoServerError.class)
+            .isThrownBy(() -> new ReplaceRootStage(json("newRoot: '$a.c'")).replaceRoot(json("a: { b: {} }")))
+            .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: MISSING. Type of resulting value: 'missing'. Input document: {a: {b: {}}}");
+    }
+
+}

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractAggregationTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractAggregationTest.java
@@ -707,6 +707,30 @@ public abstract class AbstractAggregationTest extends AbstractTest {
             );
     }
 
+    @Test
+    public void testAggregateWithReplaceRoot() {
+        Document replaceRoot = json("$replaceRoot: { newRoot: '$a.b' }");
+        List<Document> pipeline = Collections.singletonList(replaceRoot);
+
+        assertThat(collection.aggregate(pipeline)).isEmpty();
+        collection.insertOne(json("_id: 1, a: { b: { c: 10 } }"));
+
+        assertThat(toArray(collection.aggregate(pipeline)))
+            .containsExactly(json("c: 10"));
+    }
+
+    @Test
+    public void testAggregateWithProjectingReplaceRoot() {
+        Document replaceRoot = json("$replaceRoot: { newRoot: { x: '$a.b' } }");
+        List<Document> pipeline = Collections.singletonList(replaceRoot);
+
+        assertThat(collection.aggregate(pipeline)).isEmpty();
+        collection.insertOne(json("_id: 1, a: { b: { c: 10 } }"));
+
+        assertThat(toArray(collection.aggregate(pipeline)))
+            .containsExactly(json("x: { c: 10 }"));
+    }
+
     private static Date date(String instant) {
         return Date.from(Instant.parse(instant));
     }


### PR DESCRIPTION
This PR adds support to [`$replaceRoot` aggregation stage](https://docs.mongodb.com/manual/reference/operator/aggregation/replaceRoot/)
Most of the work done by `Expression.evaluateDocument`.

Still unsure how to produce error messages like Mongo does:
- Mongo prints the resolved value. I could manage basic types but not others like binary.
- Mongo prints the resolved value path only, and not the whole input document like this PR does.

I will keep working on these issues, suggestions from the more experienced are welcome!

By the way, this project is an awesome work and excellent code quality. Congratz :)