### PR TITLE
Using Json.toJsonValue to get resolved new root value in $replaceRoot error message.

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStage.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStage.java
@@ -7,6 +7,7 @@ import java.util.stream.Stream;
 import de.bwaldvogel.mongo.backend.Missing;
 import de.bwaldvogel.mongo.backend.aggregation.Expression;
 import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.bson.Json;
 import de.bwaldvogel.mongo.exception.MongoServerError;
 
 public class ReplaceRootStage implements AggregationStage {
@@ -30,22 +31,11 @@ public class ReplaceRootStage implements AggregationStage {
         Object evaluatedNewRoot = Expression.evaluateDocument(newRoot, document);
 
         if (!(evaluatedNewRoot instanceof Document)) {
-            throw new MongoServerError(40228, "'newRoot' expression must evaluate to an object, but resulting value was: " + toString(evaluatedNewRoot)
+            throw new MongoServerError(40228, "'newRoot' expression must evaluate to an object, but resulting value was: " + Json.toJsonValue(evaluatedNewRoot, true, "{", "}")
                 + ". Type of resulting value: '" + describeType(evaluatedNewRoot)
-                + "'. Input document: " + document.toString(true)); // TODO: Mongo will only show the matched element (if any). How to get it?
+                + "'. Input document: " + document.toString(true));
         }
 
         return (Document) evaluatedNewRoot;
-    }
-
-    private static String toString(Object subject) {
-        if (Missing.class.isAssignableFrom(subject.getClass())) {
-            return "MISSING";
-        }
-        if (String.class.isAssignableFrom(subject.getClass())) {
-            return "\"" + subject + "\"";
-        }
-        // TODO: how to serialize other types e.g. BIN_DATA?
-        return subject.toString();
     }
 }

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStageTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/ReplaceRootStageTest.java
@@ -34,12 +34,16 @@ public class ReplaceRootStageTest {
             .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: 1. Type of resulting value: 'int'. Input document: {a: {b: {}}}");
 
         assertThatExceptionOfType(MongoServerError.class)
+            .isThrownBy(() -> new ReplaceRootStage(json("newRoot: 'x'")).replaceRoot(json("a: { b: {} }")))
+            .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: \"x\". Type of resulting value: 'string'. Input document: {a: {b: {}}}");
+
+        assertThatExceptionOfType(MongoServerError.class)
             .isThrownBy(() -> new ReplaceRootStage(json("newRoot: '$c'")).replaceRoot(json("a: { b: {} }")))
-            .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: MISSING. Type of resulting value: 'missing'. Input document: {a: {b: {}}}");
+            .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: null. Type of resulting value: 'missing'. Input document: {a: {b: {}}}");
 
         assertThatExceptionOfType(MongoServerError.class)
             .isThrownBy(() -> new ReplaceRootStage(json("newRoot: '$a.c'")).replaceRoot(json("a: { b: {} }")))
-            .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: MISSING. Type of resulting value: 'missing'. Input document: {a: {b: {}}}");
+            .withMessage("[Error 40228] 'newRoot' expression must evaluate to an object, but resulting value was: null. Type of resulting value: 'missing'. Input document: {a: {b: {}}}");
     }
 
 }


### PR DESCRIPTION
Applies suggestion in #49: use `Json.toJsonValue` to include resolved value in error message.