### PR TITLE
Issue 64

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/FieldUpdates.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/FieldUpdates.java
@@ -343,6 +343,10 @@ class FieldUpdates {
 
     private void applyRenames() {
         for (Entry<String, String> entry : renames.entrySet()) {
+            if (!Utils.canFullyTraverseSubkeyForRename(document, entry.getKey())) {
+                throw new MongoServerException("cannot traverse element");
+            }
+
             Object value = Utils.removeSubdocumentValue(document, entry.getKey(), matchPos);
 
             if (value != Missing.getInstance()) {

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/FieldUpdates.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/FieldUpdates.java
@@ -22,6 +22,7 @@ import de.bwaldvogel.mongo.exception.FailedToParseException;
 import de.bwaldvogel.mongo.exception.ImmutableFieldException;
 import de.bwaldvogel.mongo.exception.MongoServerError;
 import de.bwaldvogel.mongo.exception.MongoServerException;
+import de.bwaldvogel.mongo.exception.PathNotViableException;
 import de.bwaldvogel.mongo.exception.TypeMismatchException;
 
 class FieldUpdates {
@@ -344,12 +345,12 @@ class FieldUpdates {
     private void applyRenames() {
         for (Entry<String, String> entry : renames.entrySet()) {
             if (!Utils.canFullyTraverseSubkeyForRename(document, entry.getKey())) {
-                throw new MongoServerException("cannot traverse element");
+                throw new PathNotViableException("cannot traverse element");
             }
 
             Object value = Utils.removeSubdocumentValue(document, entry.getKey(), matchPos);
 
-            if (value != Missing.getInstance()) {
+            if (!(value instanceof Missing)) {
                 changeSubdocumentValue(document, entry.getValue(), value);
             }
         }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/FieldUpdates.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/FieldUpdates.java
@@ -344,7 +344,10 @@ class FieldUpdates {
     private void applyRenames() {
         for (Entry<String, String> entry : renames.entrySet()) {
             Object value = Utils.removeSubdocumentValue(document, entry.getKey(), matchPos);
-            changeSubdocumentValue(document, entry.getValue(), value);
+
+            if (value != Missing.getInstance()) {
+                changeSubdocumentValue(document, entry.getValue(), value);
+            }
         }
     }
 

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/Utils.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/Utils.java
@@ -268,7 +268,7 @@ public class Utils {
             Object subObject = Utils.getFieldValueListSafe(document, mainKey);
             if (subObject instanceof Document) {
                 return canFullyTraverseSubkeyForRename(subObject, subKey);
-            } else if (subObject == Missing.getInstance()) {
+            } else if (subObject instanceof Missing) {
                 return true;
             } else {
                 return false;
@@ -422,7 +422,7 @@ public class Utils {
                 return removeSubdocumentValue(subObject, subKey, matchPos);
             } else if (!isNullOrEmpty(subKey)) { // not missing, but not a Document or List, so no subdocuments
                 return Missing.getInstance();
-            } else if (subObject == Missing.getInstance()) {
+            } else if (subObject instanceof Missing) {
                 return Missing.getInstance();
             } else {
                 throw new MongoServerException("failed to remove subdocument");

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/Utils.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/Utils.java
@@ -260,6 +260,24 @@ public class Utils {
         }
     }
 
+    static boolean canFullyTraverseSubkeyForRename(Object document, String key) {
+        int dotPos = key.indexOf('.');
+        if (dotPos > 0) {
+            String mainKey = key.substring(0, dotPos);
+            String subKey = getSubkey(key, dotPos, new AtomicReference<>());
+            Object subObject = Utils.getFieldValueListSafe(document, mainKey);
+            if (subObject instanceof Document) {
+                return canFullyTraverseSubkeyForRename(subObject, subKey);
+            } else if (subObject == Missing.getInstance()) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return true;
+        }
+    }
+
     static String getSubkey(String key, int dotPos, AtomicReference<Integer> matchPos) {
         String subKey = key.substring(dotPos + 1);
 

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/Utils.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/Utils.java
@@ -417,15 +417,14 @@ public class Utils {
         if (dotPos > 0) {
             String mainKey = key.substring(0, dotPos);
             String subKey = getSubkey(key, dotPos, matchPos);
+
+            Assert.notNullOrEmpty(subKey);
+
             Object subObject = getFieldValueListSafe(document, mainKey);
             if (subObject instanceof Document || subObject instanceof List<?>) {
                 return removeSubdocumentValue(subObject, subKey, matchPos);
-            } else if (!isNullOrEmpty(subKey)) { // not missing, but not a Document or List, so no subdocuments
-                return Missing.getInstance();
-            } else if (subObject instanceof Missing) {
-                return Missing.getInstance();
             } else {
-                throw new MongoServerException("failed to remove subdocument");
+                return Missing.getInstance();
             }
         } else {
             return removeListSafe(document, key);
@@ -482,9 +481,5 @@ public class Utils {
         response.put("cursor", cursor);
         markOkay(response);
         return response;
-    }
-
-    static boolean isNullOrEmpty(String str) {
-        return str == null || str.isEmpty();
     }
 }

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/UtilsTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/UtilsTest.java
@@ -207,21 +207,31 @@ public class UtilsTest {
 
     @Test
     public void testRemoveSubdocumentValue() throws Exception {
-        Document document = json("_id: 1, foo: {bar: 1, bla: 2}");
+        Document document = json("_id: 1, foo: {bar: 1, bla: 2}, baz: { bar: { a: 1, b: 2 } }");
 
         Object removedValue = Utils.removeSubdocumentValue(document, "foo.bar");
         assertThat(removedValue).isEqualTo(1);
-        assertThat(document).isEqualTo(json("_id: 1, foo: {bla: 2}"));
+        assertThat(document).isEqualTo(json("_id: 1, foo: {bla: 2}, baz: { bar: { a: 1, b: 2 } }"));
 
         removedValue = Utils.removeSubdocumentValue(document, "foo.bla");
         assertThat(removedValue).isEqualTo(2);
-        assertThat(document).isEqualTo(json("_id: 1, foo: {}"));
+        assertThat(document).isEqualTo(json("_id: 1, foo: {}, baz: { bar: { a: 1, b: 2 } }"));
+
+        removedValue = Utils.removeSubdocumentValue(document, "foo.missing.a");
+        assertThat(removedValue).isEqualTo(Missing.getInstance());
+        assertThat(document).isEqualTo(json("_id: 1, foo: {}, baz: { bar: { a: 1, b: 2 } }"));
 
         Utils.changeSubdocumentValue(document, "foo", json("x: [1, 2, 3]"));
-        assertThat(document).isEqualTo(json("_id: 1, foo: {x: [1, 2, 3]}"));
+        assertThat(document).isEqualTo(json("_id: 1, foo: {x: [1, 2, 3]}, baz: { bar: { a: 1, b: 2 } }"));
 
         Utils.removeSubdocumentValue(document, "foo.x.1");
-        assertThat(document).isEqualTo(json("_id: 1, foo: {x: [1, null, 3]}"));
+        assertThat(document).isEqualTo(json("_id: 1, foo: {x: [1, null, 3]}, baz: { bar: { a: 1, b: 2 } }"));
+
+        Utils.removeSubdocumentValue(document, "foo.x.a");
+        assertThat(document).isEqualTo(json("_id: 1, foo: {x: [1, null, 3]}, baz: { bar: { a: 1, b: 2 } }"));
+
+        Utils.removeSubdocumentValue(document, "baz.bar.a.z");
+        assertThat(document).isEqualTo(json("_id: 1, foo: {x: [1, null, 3]}, baz: { bar: { a: 1, b: 2 } }"));
     }
 
 }

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/UtilsTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/UtilsTest.java
@@ -234,4 +234,36 @@ public class UtilsTest {
         assertThat(document).isEqualTo(json("_id: 1, foo: {x: [1, null, 3]}, baz: { bar: { a: 1, b: 2 } }"));
     }
 
+    @Test
+    public void testCanFullyTraverseSubkeyForRename() {
+        Document document = json("_id: 1, foo: {bar: 1, bla: 2}, baz: { bar: [ { a:1, b:2} , 2, 3] }");
+
+        boolean ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "foo.bar");
+        assertThat(ableToTraverse).isTrue();
+
+        ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "foo.bar.missing");
+        assertThat(ableToTraverse).isFalse();
+
+        ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "foo.missing");
+        assertThat(ableToTraverse).isTrue();
+
+        ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "baz.bar");
+        assertThat(ableToTraverse).isTrue();
+
+        ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "baz.bar.0");
+        assertThat(ableToTraverse).isFalse();
+
+        ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "baz.bar.0.a");
+        assertThat(ableToTraverse).isFalse();
+
+        ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "baz.bar.foo");
+        assertThat(ableToTraverse).isFalse();
+
+        ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "missing");
+        assertThat(ableToTraverse).isTrue();
+
+        ableToTraverse = Utils.canFullyTraverseSubkeyForRename(document, "missing.a");
+        assertThat(ableToTraverse).isTrue();
+    }
+
 }

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
@@ -3116,7 +3116,7 @@ public abstract class AbstractBackendTest extends AbstractTest {
         collection.updateOne(json("_id: 1"), json("$rename: {'foo.a': 'a', 'bar.x': 'bar.c'}"));
         assertThat(collection.find().first()).isEqualTo(json("_id: 1, foo: { b: 2 }, bar: { c: 3, d: 4 }, a: 1}"));
 
-        assertThatExceptionOfType(Exception.class).isThrownBy(
+        assertThatExceptionOfType(MongoWriteException.class).isThrownBy(
             () -> collection.updateOne(json("_id: 1"), json("$rename: {'foo.b.c': 'foo.b.d'}")
         ));
     }

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
@@ -3116,8 +3116,9 @@ public abstract class AbstractBackendTest extends AbstractTest {
         collection.updateOne(json("_id: 1"), json("$rename: {'foo.a': 'a', 'bar.x': 'bar.c'}"));
         assertThat(collection.find().first()).isEqualTo(json("_id: 1, foo: { b: 2 }, bar: { c: 3, d: 4 }, a: 1}"));
 
-        collection.updateOne(json("_id: 1"), json("$rename: {'foo.b.c': 'foo.b.d'}"));
-        assertThat(collection.find().first()).isEqualTo(json("_id: 1, foo: { b: 2 }, bar: { c: 3, d: 4 }, a: 1}"));
+        assertThatExceptionOfType(Exception.class).isThrownBy(
+            () -> collection.updateOne(json("_id: 1"), json("$rename: {'foo.b.c': 'foo.b.d'}")
+        ));
     }
 
     @Test


### PR DESCRIPTION
Fixes #64.

Several changes in this one:
- During a rename, if the source key does not exist, don't do anything
- During key removal, if the key doesn't exist, treat the value as missing rather than null
- During key removal, if the key references an array and the key is not a number, treat the value as missing rather than throwing an exception
- During key removal while traversing subdocuments, if a value exists for the current level but it is not a Document or a List, treat it as missing
- During key removal while traversing subdocuments, if the current key references a subvalue that doesn't exist, treat it as missing
- If a rename is happening, verify that the source document we're renaming is valid (not part of an array)