### PR TITLE
Don't use unsupported indexes

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractUniqueIndex.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractUniqueIndex.java
@@ -97,6 +97,11 @@ public abstract class AbstractUniqueIndex<P> extends Index<P> {
         for (String key : keys()) {
             Object queryValue = query.get(key);
             if (queryValue instanceof Document) {
+                if (isCompoundIndex()) {
+                    // https://github.com/bwaldvogel/mongo-java-server/issues/80
+                    // Not yet supported. Use some other index, or none:
+                    return false;
+                }
                 if (BsonRegularExpression.isRegularExpression(queryValue)) {
                     return true;
                 }

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
@@ -3054,6 +3054,21 @@ public abstract class AbstractBackendTest extends AbstractTest {
             );
     }
 
+    // https://github.com/bwaldvogel/mongo-java-server/issues/80
+    @Test
+    public void testCompoundUniqueIndicesWithInQuery() {
+        collection.createIndex(json("a: 1, b: 1"), new IndexOptions().unique(true));
+
+        collection.insertOne(json("_id: 1"));
+        collection.insertOne(json("_id: 2, a: 'foo'"));
+        collection.insertOne(json("_id: 3, b: 'foo'"));
+        collection.insertOne(json("_id: 4, a: 'foo', b: 'foo'"));
+        collection.insertOne(json("_id: 5, a: 'foo', b: 'bar'"));
+
+        assertThat(toArray(collection.find(json("a: 'foo', b: { $in: ['bar'] }"))))
+            .hasSize(1);
+    }
+
     @Test
     public void testCursorOptionNoTimeout() throws Exception {
         try (MongoCursor<Document> cursor = collection.find().noCursorTimeout(true).iterator()) {


### PR DESCRIPTION
Compound indexes aren't supported when the queryValue is a Document.

This updates AbstractUniqueIndex.canHandle() to return false in those cases, so that we don't use that index and cause an exception.

Fixes: https://github.com/bwaldvogel/mongo-java-server/issues/80