### PR TITLE
Adding support for the `$reduce` operator

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/Expression.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/Expression.java
@@ -1327,7 +1327,7 @@ public enum Expression implements ExpressionTraits {
                 }
                 return exp.apply(expressionValue, document);
             } else {
-                result.put(expressionKey, expressionValue);
+                result.put(expressionKey, evaluate(expressionValue, document));
             }
         }
         return result;

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/ExpressionTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/ExpressionTest.java
@@ -406,6 +406,14 @@ public class ExpressionTest {
             json("quizzes: [5, 6, 7]")))
             .isEqualTo(18);
 
+        final Document expectedDocument = new Document();
+        expectedDocument.put("sum", 15);
+        expectedDocument.put("product", 48.0);
+        assertThat(Expression.evaluate(
+            json("$reduce: {input: '$quizzes', initialValue: { sum: 5, product: 2 }, in: {sum: {$add : ['$$value.sum', '$$this']},product: {$multiply: [ '$$value.product', '$$this' ]}}}"),
+            json("quizzes: [ 1, 2, 3, 4 ]")))
+            .isEqualTo(expectedDocument);
+
         assertThat((Collection<Object>) Expression.evaluate(
             json("$reduce: {input: '$quizzes',initialValue: [ 1, 2 ],in: {$concatArrays : ['$$value', '$$this']}}"),
             json("quizzes: [ [ 3, 4 ], [ 5, 6 ] ]")))


### PR DESCRIPTION
While I was testing an aggregation pipeline in one of my projects, I encountered the following error:

`de.bwaldvogel.mongo.exception.MongoServerError: [Error 168] Unrecognized expression '$reduce'`

I realized that the [$reduce](https://docs.mongodb.com/manual/reference/operator/aggregation/reduce/) operator was missing in [Expression.java](https://github.com/bwaldvogel/mongo-java-server/blob/master/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/Expression.java).
Therefore, I added support for this operator in this PR and now I'm looking forward to feedback.

