### PR TITLE
Enable comparison of bsontimestamps

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/ValueComparator.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/ValueComparator.java
@@ -7,10 +7,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.UUID;
 
-import de.bwaldvogel.mongo.bson.BsonRegularExpression;
-import de.bwaldvogel.mongo.bson.Decimal128;
-import de.bwaldvogel.mongo.bson.Document;
-import de.bwaldvogel.mongo.bson.ObjectId;
+import de.bwaldvogel.mongo.bson.*;
 
 public class ValueComparator implements Comparator<Object> {
 
@@ -48,6 +45,7 @@ public class ValueComparator implements Comparator<Object> {
         SORT_PRIORITY.add(ObjectId.class);
         SORT_PRIORITY.add(Boolean.class);
         SORT_PRIORITY.add(Instant.class);
+        SORT_PRIORITY.add(BsonTimestamp.class);
         SORT_PRIORITY.add(BsonRegularExpression.class);
     }
 
@@ -133,6 +131,12 @@ public class ValueComparator implements Comparator<Object> {
             Instant date1 = (Instant) value1;
             Instant date2 = (Instant) value2;
             return date1.compareTo(date2);
+        }
+
+        if(BsonTimestamp.class.isAssignableFrom(clazz)) {
+            BsonTimestamp bt1 = (BsonTimestamp) value1;
+            BsonTimestamp bt2 = (BsonTimestamp) value2;
+            return Long.compare(bt1.getTimestamp(), bt2.getTimestamp());
         }
 
         if (Boolean.class.isAssignableFrom(clazz)) {

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/ValueComparatorTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/ValueComparatorTest.java
@@ -110,7 +110,7 @@ public class ValueComparatorTest {
     public void testCompareTimestamps() {
         BsonTimestamp bsonTimestamp = new BsonTimestamp(12345L);
         BsonTimestamp bsonTimestamp2 = new BsonTimestamp(67890L);
-        assertComparesTheSame(bsonTimestamp, bsonTimestamp);
+        assertComparesTheSame(bsonTimestamp, new BsonTimestamp(12345L));
         assertFirstValueBeforeSecondValue(bsonTimestamp,bsonTimestamp2);
     }
 

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/ValueComparatorTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/ValueComparatorTest.java
@@ -10,6 +10,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.UUID;
 
+import de.bwaldvogel.mongo.bson.BsonTimestamp;
 import org.junit.Test;
 
 import de.bwaldvogel.mongo.bson.Decimal128;
@@ -103,6 +104,14 @@ public class ValueComparatorTest {
         assertFirstValueBeforeSecondValue(58.9999, 59);
         assertFirstValueBeforeSecondValue(null, 27);
         assertComparesTheSame(-0.0, 0.0);
+    }
+
+    @Test
+    public void testCompareTimestamps() {
+        BsonTimestamp bsonTimestamp = new BsonTimestamp(12345L);
+        BsonTimestamp bsonTimestamp2 = new BsonTimestamp(67890L);
+        assertComparesTheSame(bsonTimestamp, bsonTimestamp);
+        assertFirstValueBeforeSecondValue(bsonTimestamp,bsonTimestamp2);
     }
 
     @Test


### PR DESCRIPTION
Fixes: https://github.com/bwaldvogel/mongo-java-server/issues/105 
