### PR TITLE
Add support for nested fields in $lookup stage

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStage.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStage.java
@@ -1,6 +1,6 @@
 package de.bwaldvogel.mongo.backend.aggregation.stage;
 
-import static java.util.stream.Collectors.*;
+import static java.util.stream.Collectors.toList;
 
 import java.util.HashSet;
 import java.util.List;
@@ -9,6 +9,7 @@ import java.util.stream.Stream;
 
 import de.bwaldvogel.mongo.MongoCollection;
 import de.bwaldvogel.mongo.MongoDatabase;
+import de.bwaldvogel.mongo.backend.Utils;
 import de.bwaldvogel.mongo.bson.Document;
 
 public class LookupStage extends AbstractLookupStage {
@@ -46,7 +47,7 @@ public class LookupStage extends AbstractLookupStage {
     }
 
     private Document resolveRemoteField(Document document) {
-        Object value = document.get(localField);
+        Object value = Utils.getSubdocumentValue(document, localField);
         List<Document> documents = lookupValue(value);
         Document result = document.clone();
         result.put(as, documents);

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStageTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStageTest.java
@@ -135,6 +135,8 @@ public class LookupStageTest extends AbstractLookupStageTest {
 
     @Test
     public void testLookupWithNestedField() throws Exception {
+        prepareAuthorsCollectionMock();
+
         LookupStage lookupStage = buildLookupStage("from: 'authors', 'localField': 'author.id', foreignField: '_id', as: 'author'");
         configureAuthorsCollection("_id: 3", "_id: 3, name: 'Uncle Bob'");
         Document document = json("title: 'Clean Code', author: { id: 3 }");

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStageTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupStageTest.java
@@ -133,6 +133,19 @@ public class LookupStageTest extends AbstractLookupStageTest {
         );
     }
 
+    @Test
+    public void testLookupWithNestedField() throws Exception {
+        LookupStage lookupStage = buildLookupStage("from: 'authors', 'localField': 'author.id', foreignField: '_id', as: 'author'");
+        configureAuthorsCollection("_id: 3", "_id: 3, name: 'Uncle Bob'");
+        Document document = json("title: 'Clean Code', author: { id: 3 }");
+
+        Stream<Document> result = lookupStage.apply(Stream.of(document));
+
+        assertThat(result).containsExactly(
+            json("title: 'Clean Code', author: { id: 3 }, author: [{_id: 3, name: 'Uncle Bob'}]")
+        );
+    }
+
     private LookupStage buildLookupStage(String jsonDocument) {
         return new LookupStage(json(jsonDocument), database);
     }


### PR DESCRIPTION
A pipeline with a $lookup on a nested field is currently not working. With this PR the needed functionality will be added.