### PR TITLE
Change streams implementation

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.util.Collection;
 import java.util.List;
 
+import de.bwaldvogel.mongo.backend.MongoBackendClock;
 import de.bwaldvogel.mongo.backend.QueryResult;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.wire.message.MongoDelete;
@@ -40,12 +41,16 @@ public interface MongoBackend {
 
     void close();
 
-    Clock getClock();
+    MongoBackendClock getClock();
 
     void setClock(Clock clock);
+
+    void setClock(MongoBackendClock clock);
 
     void enableOplog();
 
     void disableOplog();
+
+    MongoDatabase resolveDatabase(String database);
 
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/MongoCollection.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoCollection.java
@@ -61,10 +61,6 @@ public interface MongoCollection<P> {
 
     QueryResult handleQuery(Document query, int numberToSkip, int numberToReturn, Document returnFieldSelector);
 
-    QueryResult handleGetMore(long cursorId, int numberToReturn);
-
-    void handleKillCursors(MongoKillCursors killCursors);
-
     default void insertDocuments(List<Document> documents) {
         int index = 0;
         for (Document document : documents) {

--- a/core/src/main/java/de/bwaldvogel/mongo/MongoDatabase.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoDatabase.java
@@ -22,10 +22,6 @@ public interface MongoDatabase {
 
     QueryResult handleQuery(MongoQuery query);
 
-    QueryResult handleGetMore(MongoGetMore getMore);
-
-    void handleKillCursors(MongoKillCursors killCursors);
-
     void handleInsert(MongoInsert insert, Oplog oplog);
 
     void handleDelete(MongoDelete delete, Oplog oplog);

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractCursor.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractCursor.java
@@ -1,0 +1,28 @@
+package de.bwaldvogel.mongo.backend;
+
+import de.bwaldvogel.mongo.bson.Document;
+
+import java.util.Collections;
+import java.util.List;
+
+public abstract class AbstractCursor implements Cursor {
+
+    protected final long cursorId;
+    protected List<Document> remainingDocuments;
+
+    protected AbstractCursor(long cursorId, List<Document> remainingDocuments) {
+        this.cursorId = cursorId;
+        this.remainingDocuments = Collections.unmodifiableList(remainingDocuments);
+    }
+
+    @Override
+    public long getCursorId() {
+        return cursorId;
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getSimpleName() + "(id: " + cursorId + ")";
+    }
+
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractSynchronizedMongoCollection.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractSynchronizedMongoCollection.java
@@ -9,8 +9,10 @@ import de.bwaldvogel.mongo.wire.message.MongoKillCursors;
 
 public abstract class AbstractSynchronizedMongoCollection<P> extends AbstractMongoCollection<P> {
 
-    protected AbstractSynchronizedMongoCollection(MongoDatabase database, String collectionName, CollectionOptions options) {
-        super(database, collectionName, options);
+    protected AbstractSynchronizedMongoCollection(MongoDatabase database, String collectionName,
+                                                  CollectionOptions options,
+                                                  CursorFactory cursorFactory) {
+        super(database, collectionName, options, cursorFactory);
     }
 
     @Override
@@ -27,16 +29,6 @@ public abstract class AbstractSynchronizedMongoCollection<P> extends AbstractMon
     public synchronized QueryResult handleQuery(Document queryObject, int numberToSkip, int numberToReturn,
                                                 Document fieldSelector) {
         return super.handleQuery(queryObject, numberToSkip, numberToReturn, fieldSelector);
-    }
-
-    @Override
-    public synchronized QueryResult handleGetMore(long cursorId, int numberToReturn) {
-        return super.handleGetMore(cursorId, numberToReturn);
-    }
-
-    @Override
-    public synchronized void handleKillCursors(MongoKillCursors killCursors) {
-        super.handleKillCursors(killCursors);
     }
 
     @Override

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/CursorFactory.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/CursorFactory.java
@@ -1,0 +1,56 @@
+package de.bwaldvogel.mongo.backend;
+
+import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.exception.CursorNotFoundException;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+public class CursorFactory {
+
+    final ConcurrentMap<Long, Cursor> cursors = new ConcurrentHashMap<>();
+    final AtomicLong cursorIdCounter = new AtomicLong();
+
+    public synchronized long getCursorId() {
+        return cursorIdCounter.incrementAndGet();
+    }
+
+    public synchronized InMemoryCursor createInMemoryCursor(Collection<Document> remainingDocuments) {
+        return createCursor(new InMemoryCursor(getCursorId(), new ArrayList<>(remainingDocuments)));
+    }
+
+    public Cursor getCursor(long cursorId) {
+        if (!cursors.containsKey(cursorId)) {
+            throw new CursorNotFoundException(String.format("Cursor id %d does not exists", cursorId));
+        }
+        return cursors.get(cursorId);
+    }
+
+    public boolean exists(long cursorId) {
+        return cursors.containsKey(cursorId);
+    }
+
+    public synchronized void remove(long cursorId) {
+        cursors.remove(cursorId);
+    }
+
+    public TailableCursor createTailableCursor(Aggregation aggregation, MongoBackendClock backendClock) {
+        return createCursor(
+            new TailableCursor(getCursorId(), aggregation, Utils.getResumeToken(backendClock.get()))
+        );
+    }
+
+    public TailableCursor createTailableCursor(Aggregation aggregation, long resumeToken) {
+        return createCursor(new TailableCursor(getCursorId(), aggregation, resumeToken));
+    }
+
+    private <T extends Cursor> T createCursor(T cursor) {
+        Cursor previousValue = cursors.put(cursor.getCursorId(), cursor);
+        Assert.isNull(previousValue);
+        return cursor;
+    }
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/FieldUpdates.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/FieldUpdates.java
@@ -393,7 +393,7 @@ class FieldUpdates {
         if (useDate) {
             newValue = now;
         } else {
-            newValue = new BsonTimestamp(now);
+            newValue = new BsonTimestamp(now.getEpochSecond());
         }
 
         changeSubdocumentValue(document, key, newValue);

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/InMemoryCursor.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/InMemoryCursor.java
@@ -1,19 +1,14 @@
 package de.bwaldvogel.mongo.backend;
 
-import java.util.Collections;
-import java.util.List;
-
 import de.bwaldvogel.mongo.bson.Document;
 
-public class InMemoryCursor implements Cursor {
+import java.util.List;
 
-    private final long cursorId;
-    private List<Document> remainingDocuments;
+public class InMemoryCursor extends AbstractCursor {
 
     public InMemoryCursor(long cursorId, List<Document> remainingDocuments) {
-        this.cursorId = cursorId;
+        super(cursorId, remainingDocuments);
         Assert.notEmpty(remainingDocuments);
-        this.remainingDocuments = Collections.unmodifiableList(remainingDocuments);
     }
 
     public int documentsCount() {
@@ -26,11 +21,6 @@ public class InMemoryCursor implements Cursor {
     }
 
     @Override
-    public long getCursorId() {
-        return cursorId;
-    }
-
-    @Override
     public List<Document> takeDocuments(int numberToReturn) {
         Assert.isTrue(numberToReturn > 0, () -> "Illegal number to return: " + numberToReturn);
         int toIndex = Math.min(remainingDocuments.size(), numberToReturn);
@@ -39,8 +29,4 @@ public class InMemoryCursor implements Cursor {
         return documents;
     }
 
-    @Override
-    public String toString() {
-        return getClass().getSimpleName() + "(id: " + cursorId + ")";
-    }
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/MongoBackendClock.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/MongoBackendClock.java
@@ -1,0 +1,60 @@
+package de.bwaldvogel.mongo.backend;
+
+import de.bwaldvogel.mongo.bson.BsonTimestamp;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class MongoBackendClock extends Clock {
+
+    private Clock clock;
+    private AtomicInteger atomicIncrement = new AtomicInteger();
+
+    public MongoBackendClock() {
+        this(Clock.systemDefaultZone());
+    }
+
+    public MongoBackendClock(Clock clock) {
+        this.clock = clock;
+    }
+
+    public synchronized BsonTimestamp increaseAndGet() {
+        return new BsonTimestamp(clock.instant().getEpochSecond(), atomicIncrement.incrementAndGet());
+    }
+
+    public synchronized BsonTimestamp get() {
+        return new BsonTimestamp(clock.instant().getEpochSecond(), atomicIncrement.get());
+    }
+
+    public synchronized BsonTimestamp getAndIncrement() {
+        return new BsonTimestamp(clock.instant().getEpochSecond(), atomicIncrement.getAndIncrement());
+    }
+
+    public synchronized void windForward(Duration duration) {
+        clock = Clock.offset(clock, duration);
+        atomicIncrement = new AtomicInteger();
+    }
+
+    @Override
+    public ZoneId getZone() {
+        return clock.getZone();
+    }
+
+    @Override
+    public Clock withZone(ZoneId zone) {
+        return clock.withZone(zone);
+    }
+
+    @Override
+    public Instant instant() {
+        return clock.instant();
+    }
+
+    public synchronized void reset(Instant instant) {
+        clock = Clock.fixed(instant, Clock.systemDefaultZone().getZone());
+        atomicIncrement = new AtomicInteger();
+    }
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/ReadOnlyProxy.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/ReadOnlyProxy.java
@@ -1,22 +1,18 @@
 package de.bwaldvogel.mongo.backend;
 
+import de.bwaldvogel.mongo.MongoBackend;
+import de.bwaldvogel.mongo.MongoDatabase;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.exception.MongoServerException;
+import de.bwaldvogel.mongo.exception.NoSuchCommandException;
+import de.bwaldvogel.mongo.wire.message.*;
+import io.netty.channel.Channel;
+
 import java.time.Clock;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import de.bwaldvogel.mongo.MongoBackend;
-import de.bwaldvogel.mongo.bson.Document;
-import de.bwaldvogel.mongo.exception.MongoServerException;
-import de.bwaldvogel.mongo.exception.NoSuchCommandException;
-import de.bwaldvogel.mongo.wire.message.MongoDelete;
-import de.bwaldvogel.mongo.wire.message.MongoGetMore;
-import de.bwaldvogel.mongo.wire.message.MongoInsert;
-import de.bwaldvogel.mongo.wire.message.MongoKillCursors;
-import de.bwaldvogel.mongo.wire.message.MongoQuery;
-import de.bwaldvogel.mongo.wire.message.MongoUpdate;
-import io.netty.channel.Channel;
 
 public class ReadOnlyProxy implements MongoBackend {
 
@@ -110,12 +106,17 @@ public class ReadOnlyProxy implements MongoBackend {
     }
 
     @Override
-    public Clock getClock() {
+    public MongoBackendClock getClock() {
         return backend.getClock();
     }
 
     @Override
     public void setClock(Clock clock) {
+        setClock(new MongoBackendClock(clock));
+    }
+
+    @Override
+    public void setClock(MongoBackendClock clock) {
         backend.setClock(clock);
     }
 
@@ -125,6 +126,11 @@ public class ReadOnlyProxy implements MongoBackend {
 
     @Override
     public void disableOplog() {
+    }
+
+    @Override
+    public MongoDatabase resolveDatabase(String database) {
+        return null;
     }
 
     @Override

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/TailableCursor.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/TailableCursor.java
@@ -1,0 +1,57 @@
+package de.bwaldvogel.mongo.backend;
+
+import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
+import de.bwaldvogel.mongo.bson.Document;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class TailableCursor extends AbstractCursor {
+
+    private final Aggregation aggregation;
+    private long resumeToken;
+
+    public TailableCursor(long cursorId, Aggregation aggregation, long resumeToken) {
+        super(cursorId, Collections.emptyList());
+        this.aggregation = aggregation;
+        this.resumeToken = resumeToken;
+        Assert.notNull(aggregation);
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return false;
+    }
+
+    @Override
+    public List<Document> takeDocuments(int numberToReturn) {
+        if (numberToReturn <= 0) {
+            return takeDocuments();
+        }
+        List<Document> documents = aggregation.computeResult().stream()
+            .filter(d -> getResumeToken(d) > resumeToken)
+            .limit(numberToReturn)
+            .collect(Collectors.toList());
+        updateResumeToken(documents);
+        return documents;
+    }
+
+    private List<Document> takeDocuments() {
+        List<Document> documents = aggregation.computeResult().stream()
+            .filter(d -> getResumeToken(d) > resumeToken)
+            .collect(Collectors.toList());
+        updateResumeToken(documents);
+        return documents;
+    }
+
+    private void updateResumeToken(List<Document> documents) {
+        if (documents.size() > 0) {
+            resumeToken = getResumeToken(documents.get(documents.size() - 1));
+        }
+    }
+
+    private long getResumeToken(Document doc) {
+        return Long.parseLong((String) ((Document)doc.get("_id")).get("_data"), 16);
+    }
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/ValueComparator.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/ValueComparator.java
@@ -164,7 +164,7 @@ public class ValueComparator implements Comparator<Object> {
         if (BsonTimestamp.class.isAssignableFrom(clazz)) {
             BsonTimestamp bt1 = (BsonTimestamp) value1;
             BsonTimestamp bt2 = (BsonTimestamp) value2;
-            return Long.compare(bt1.getTimestamp(), bt2.getTimestamp());
+            return Long.compare(bt1.getValue(), bt2.getValue());
         }
 
         if (Boolean.class.isAssignableFrom(clazz)) {

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/ChangeStreamStage.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/ChangeStreamStage.java
@@ -1,0 +1,22 @@
+package de.bwaldvogel.mongo.backend.aggregation.stage;
+
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.oplog.Oplog;
+
+import java.util.stream.Stream;
+
+public class ChangeStreamStage implements AggregationStage {
+
+    private final Document changeStreamDocument;
+    private final Oplog oplog;
+
+    public ChangeStreamStage(Document changeStreamDocument, Oplog oplog) {
+        this.changeStreamDocument = changeStreamDocument;
+        this.oplog = oplog;
+    }
+
+    @Override
+    public Stream<Document> apply(Stream<Document> stream) {
+        return oplog.handleAggregation(changeStreamDocument);
+    }
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/FacetStage.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/FacetStage.java
@@ -11,14 +11,15 @@ import de.bwaldvogel.mongo.MongoCollection;
 import de.bwaldvogel.mongo.MongoDatabase;
 import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
 import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.oplog.Oplog;
 
 public class FacetStage implements AggregationStage {
 
     private final Map<String, Aggregation> facets = new LinkedHashMap<>();
 
-    public FacetStage(Document facetsConfiguration, MongoDatabase database, MongoCollection<?> collection) {
+    public FacetStage(Document facetsConfiguration, MongoDatabase database, MongoCollection<?> collection, Oplog oplog) {
         for (Entry<String, Object> entry : facetsConfiguration.entrySet()) {
-            Aggregation aggregation = Aggregation.fromPipeline(entry.getValue(), database, collection);
+            Aggregation aggregation = Aggregation.fromPipeline(entry.getValue(), database, collection, oplog);
             facets.put(entry.getKey(), aggregation);
         }
     }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupWithPipelineStage.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupWithPipelineStage.java
@@ -12,6 +12,7 @@ import de.bwaldvogel.mongo.MongoDatabase;
 import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
 import de.bwaldvogel.mongo.backend.aggregation.Expression;
 import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.oplog.Oplog;
 
 public class LookupWithPipelineStage extends AbstractLookupStage {
 
@@ -29,13 +30,15 @@ public class LookupWithPipelineStage extends AbstractLookupStage {
     }
 
     private final MongoDatabase mongoDatabase;
+    private Oplog oplog;
     private final MongoCollection<?> collection;
     private final Document let;
     private final Object pipeline;
     private final String as;
 
-    public LookupWithPipelineStage(Document configuration, MongoDatabase mongoDatabase) {
+    public LookupWithPipelineStage(Document configuration, MongoDatabase mongoDatabase, Oplog oplog) {
         this.mongoDatabase = mongoDatabase;
+        this.oplog = oplog;
         String from = readStringConfigurationProperty(configuration, FROM);
         collection = mongoDatabase.resolveCollection(from, false);
         let = readOptionalDocumentArgument(configuration, LET_FIELD);
@@ -50,7 +53,7 @@ public class LookupWithPipelineStage extends AbstractLookupStage {
     }
 
     private Document joinDocuments(Document document) {
-        Aggregation aggregation = Aggregation.fromPipeline(pipeline, mongoDatabase, collection);
+        Aggregation aggregation = Aggregation.fromPipeline(pipeline, mongoDatabase, collection, oplog);
         aggregation.setVariables(evaluateVariables(document));
         List<Document> documents = aggregation.computeResult();
         Document result = document.clone();

--- a/core/src/main/java/de/bwaldvogel/mongo/bson/BsonTimestamp.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/bson/BsonTimestamp.java
@@ -1,26 +1,99 @@
 package de.bwaldvogel.mongo.bson;
 
-import java.time.Instant;
-
-public class BsonTimestamp implements Bson {
+public class BsonTimestamp implements Bson, Comparable<BsonTimestamp> {
 
     private static final long serialVersionUID = 1L;
+    private final long value;
 
-    private long timestamp;
-
-    protected BsonTimestamp() {
+    /**
+     * Construct a new instance with a null time and a 0 increment.
+     */
+    public BsonTimestamp() {
+        value = 0;
     }
 
-    public BsonTimestamp(Instant instant) {
-        this(instant.toEpochMilli());
+    /**
+     * Construct a new instance for the given value, which combines the time in seconds and the increment as a single long value.
+     *
+     * @param value the timetamp as a single long value
+     * @since 3.5
+     */
+    public BsonTimestamp(final long value) {
+        this.value = value;
     }
 
-    public BsonTimestamp(long timestamp) {
-        this.timestamp = timestamp;
+    /**
+     * Construct a new instance for the given time and increment.
+     *
+     * @param seconds the number of seconds since the epoch
+     * @param increment  the increment.
+     */
+    public BsonTimestamp(final long seconds, final int increment) {
+        value = (seconds << 32) | (increment & 0xFFFFFFFFL);
     }
 
-    public long getTimestamp() {
-        return timestamp;
+    /**
+     * Gets the value of the timestamp.
+     *
+     * @return the timestamp value
+     * @since 3.5
+     */
+    public long getValue() {
+        return value;
     }
 
+    /**
+     * Gets the time in seconds since epoch.
+     *
+     * @return an int representing time in seconds since epoch
+     */
+    public int getTime() {
+        return (int) (value >> 32);
+    }
+
+    /**
+     * Gets the increment value.
+     *
+     * @return an incrementing ordinal for operations within a given second
+     */
+    public int getInc() {
+        return (int) value;
+    }
+
+    @Override
+    public String toString() {
+        return "Timestamp{"
+            + "value=" + getValue()
+            + ", seconds=" + getTime()
+            + ", inc=" + getInc()
+            + '}';
+    }
+
+    @Override
+    public int compareTo(final BsonTimestamp ts) {
+        return Long.compareUnsigned(value, ts.value);
+    }
+
+    @Override
+    public boolean equals(final Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        BsonTimestamp timestamp = (BsonTimestamp) o;
+
+        if (value != timestamp.value) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return (int) (value ^ (value >>> 32));
+    }
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/oplog/CollectionBackedOplog.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/oplog/CollectionBackedOplog.java
@@ -1,25 +1,37 @@
 package de.bwaldvogel.mongo.oplog;
 
-import java.time.Clock;
-import java.time.Instant;
-import java.util.List;
-import java.util.UUID;
-
+import de.bwaldvogel.mongo.MongoBackend;
 import de.bwaldvogel.mongo.MongoCollection;
+import de.bwaldvogel.mongo.backend.Cursor;
+import de.bwaldvogel.mongo.backend.CursorFactory;
+import de.bwaldvogel.mongo.backend.MongoBackendClock;
+import de.bwaldvogel.mongo.backend.Utils;
+import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
 import de.bwaldvogel.mongo.bson.BsonTimestamp;
 import de.bwaldvogel.mongo.bson.Document;
+import sun.nio.ch.Util;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public class CollectionBackedOplog implements Oplog {
 
     private static final long ELECTION_TERM = 1L;
+    private final String START_AT_OPERATION_TIME = "startAtOperationTime";
 
-    private final Clock clock;
+    private final MongoBackendClock clock;
     private final MongoCollection<Document> collection;
+    private MongoBackend backend;
+    private CursorFactory cursorFactory;
     private final UUID ui = UUID.randomUUID();
 
-    public CollectionBackedOplog(Clock clock, MongoCollection<Document> collection) {
-        this.clock = clock;
+    public CollectionBackedOplog(MongoBackend backend, MongoCollection<Document> collection, CursorFactory cursorFactory) {
+        this.clock = backend.getClock();
         this.collection = collection;
+        this.backend = backend;
+        this.cursorFactory = cursorFactory;
     }
 
     @Override
@@ -53,17 +65,50 @@ public class CollectionBackedOplog implements Oplog {
 
     }
 
+    @Override
+    public Stream<Document> handleAggregation(Document changeStreamDocument) {
+        final long clientToken = Utils.getResumeTokenFromChangeStreamDocument(changeStreamDocument);
+        final BsonTimestamp startAtOperationTime = changeStreamDocument.containsKey(START_AT_OPERATION_TIME) ?
+            (BsonTimestamp) changeStreamDocument.get(START_AT_OPERATION_TIME) : null;
+
+        List<Document> res = collection.queryAllAsStream()
+            .filter(document -> {
+                if (startAtOperationTime != null) {
+                    BsonTimestamp serverTs = (BsonTimestamp) document.get("ts");
+                    return serverTs.compareTo(startAtOperationTime) >= 0;
+                }
+                return Utils.getResumeToken((BsonTimestamp) document.get("ts")) > clientToken;
+            })
+            .sorted((o1, o2) -> {
+                BsonTimestamp timestamp1 = (BsonTimestamp) o1.get("ts");
+                BsonTimestamp timestamp2 = (BsonTimestamp) o2.get("ts");
+                return timestamp1.compareTo(timestamp2);
+            })
+            .map(document -> getChangeStreamResponseDocument(document, changeStreamDocument))
+            .collect(Collectors.toList());
+        return res.stream();
+    }
+
+    @Override
+    public Cursor createCursor(Aggregation aggregation) {
+        return cursorFactory.createTailableCursor(aggregation, clock);
+    }
+
+    @Override
+    public Cursor createCursor(Aggregation aggregation, long resumeToken) {
+        return cursorFactory.createTailableCursor(aggregation, resumeToken);
+    }
+
     private Document toOplogDocument(OperationType operationType, String namespace) {
-        Instant now = clock.instant();
         return new Document()
-            .append("ts", new BsonTimestamp(now))
+            .append("ts", clock.increaseAndGet())
             .append("t", ELECTION_TERM)
             .append("h", 0L)
             .append("v", 2L)
             .append("op", operationType.getCode())
             .append("ns", namespace)
             .append("ui", ui)
-            .append("wall", now);
+            .append("wall", clock.instant());
     }
 
     private Document toOplogInsertDocument(String namespace, Document document) {
@@ -84,6 +129,64 @@ public class CollectionBackedOplog implements Oplog {
 
     private boolean isOplogCollection(String namespace) {
         return collection.getFullName().equals(namespace);
+    }
+
+    private Document getFullDocument(Document changeStreamDocument, Document document, OperationType operationType) {
+        switch (operationType) {
+            case INSERT:
+                return (Document) document.get("o");
+            case DELETE:
+                return null;
+            case UPDATE:
+                return lookUpUpdateDocument(changeStreamDocument, document);
+        }
+        throw new IllegalArgumentException("Invalid operation type");
+    }
+
+    private Document lookUpUpdateDocument(Document changeStreamDocument, Document document) {
+        if (changeStreamDocument.containsKey("fullDocument") && changeStreamDocument.get("fullDocument").equals("updateLookup")) {
+            String namespace = (String)document.get("ns");
+            String databaseName = namespace.split("\\.")[0];
+            String collectionName = namespace.split("\\.")[1];
+            return backend.resolveDatabase(databaseName)
+                .resolveCollection(collectionName, true)
+                .queryAllAsStream().filter(d -> d.get("_id").equals(((Document)document.get("o2")).get("_id")))
+                .findFirst().orElse(getDeltaUpdate((Document) document.get("o")));
+        }
+        return getDeltaUpdate((Document) document.get("o"));
+    }
+
+    private Document getDeltaUpdate(Document updateDocument) {
+        Document delta = new Document();
+        if (updateDocument.containsKey("$set")) {
+            delta.appendAll((Document)updateDocument.get("$set"));
+        }
+        if (updateDocument.containsKey("$unset")) {
+            delta.appendAll((Document)updateDocument.get("$unset"));
+        }
+        return delta;
+    }
+
+    private Document getChangeStreamResponseDocument(Document oplogDocument, Document changeStreamDocument) {
+        OperationType operationType = OperationType.fromCode(oplogDocument.get("op").toString());
+        Document documentKey = new Document();
+        switch (operationType) {
+            case UPDATE:
+                documentKey = (Document)oplogDocument.get("o2");
+                break;
+            case INSERT:
+                documentKey.append("_id", ((Document)oplogDocument.get("o")).get("_id"));
+                break;
+            case DELETE:
+                documentKey = (Document)oplogDocument.get("o");
+                break;
+        }
+        return new Document()
+            .append("_id", new Document("_data", Utils.getResumeTokenAsHEX((BsonTimestamp) oplogDocument.get("ts")))) //This is going to be the resume token
+            .append("operationType", operationType.getDescription())
+            .append("fullDocument", getFullDocument(changeStreamDocument, oplogDocument, operationType))
+            .append("documentKey", documentKey)
+            .append("clusterTime", oplogDocument.get("ts"));
     }
 
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/oplog/NoopOplog.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/oplog/NoopOplog.java
@@ -1,8 +1,11 @@
 package de.bwaldvogel.mongo.oplog;
 
-import java.util.List;
-
+import de.bwaldvogel.mongo.backend.Cursor;
+import de.bwaldvogel.mongo.backend.EmptyCursor;
+import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
 import de.bwaldvogel.mongo.bson.Document;
+
+import java.util.List;
 
 public final class NoopOplog implements Oplog {
 
@@ -25,5 +28,15 @@ public final class NoopOplog implements Oplog {
 
     @Override
     public void handleDelete(String namespace, Document query, List<Object> deletedIds) {
+    }
+
+    @Override
+    public Cursor createCursor(Aggregation aggregation) {
+        return EmptyCursor.get();
+    }
+
+    @Override
+    public Cursor createCursor(Aggregation aggregation, long resumeToken) {
+        return EmptyCursor.get();
     }
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/oplog/OperationType.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/oplog/OperationType.java
@@ -36,4 +36,16 @@ public enum OperationType {
         }
         return operationType;
     }
+
+    String getDescription() {
+        switch (this) {
+            case DELETE:
+                return "delete";
+            case INSERT:
+                return "insert";
+            case UPDATE:
+                return "update";
+        }
+        return null;
+    }
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/oplog/Oplog.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/oplog/Oplog.java
@@ -1,7 +1,10 @@
 package de.bwaldvogel.mongo.oplog;
 
 import java.util.List;
+import java.util.stream.Stream;
 
+import de.bwaldvogel.mongo.backend.Cursor;
+import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
 import de.bwaldvogel.mongo.bson.Document;
 
 public interface Oplog {
@@ -11,4 +14,12 @@ public interface Oplog {
     void handleUpdate(String namespace, Document selector, Document query, List<Object> modifiedIds);
 
     void handleDelete(String namespace, Document query, List<Object> deletedIds);
+
+    default Stream<Document> handleAggregation(Document changeStreamDocument) {
+        return Stream.empty();
+    };
+
+    Cursor createCursor(Aggregation aggregation);
+
+    Cursor createCursor(Aggregation aggregation, long resumeToken);
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/wire/bson/BsonEncoder.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/wire/bson/BsonEncoder.java
@@ -135,7 +135,7 @@ public class BsonEncoder {
                 break;
             case BsonConstants.TYPE_TIMESTAMP:
                 BsonTimestamp timestamp = (BsonTimestamp) value;
-                buffer.writeLongLE(timestamp.getTimestamp());
+                buffer.writeLongLE(timestamp.getValue());
                 break;
             case BsonConstants.TYPE_INT64:
                 buffer.writeLongLE(((Long) value).longValue());

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoBackendTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoBackendTest.java
@@ -1,0 +1,56 @@
+package de.bwaldvogel.mongo.backend;
+
+import de.bwaldvogel.mongo.MongoBackend;
+import de.bwaldvogel.mongo.MongoDatabase;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.wire.message.MongoGetMore;
+import de.bwaldvogel.mongo.wire.message.MongoKillCursors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractMongoBackendTest {
+
+    private MongoBackend backend;
+    private CursorFactory cursorFactory = new CursorFactory();
+
+    @BeforeEach
+    public void setup() {
+        backend = new AbstractMongoBackend() {
+            @Override
+            protected MongoDatabase openOrCreateDatabase(String databaseName) {
+                return null;
+            }
+        };
+    }
+
+    @Test
+    void testGetMore_shouldDeleteCursorIfEmpty() {
+        Collection<Document> docs = Arrays.asList(new Document("name", "Joe"), new Document("name", "Mary"),
+            new Document("name", "Steve"));
+        Cursor cursor = cursorFactory.createInMemoryCursor(docs);
+        MongoGetMore getMore = new MongoGetMore(null, null, "testcoll", 3,
+            cursor.getCursorId());
+        backend.handleGetMore(getMore);
+        assertThat(cursorFactory.exists(cursor.getCursorId())).isFalse();
+    }
+
+    @Test
+    void testHandleKillCursor() {
+        Cursor cursor1 = cursorFactory.createInMemoryCursor(Collections.singleton(new Document()));
+        Cursor cursor2 = cursorFactory.createInMemoryCursor(Collections.singleton(new Document()));
+        assertThat(cursorFactory.exists(cursor1.getCursorId())).isTrue();
+        assertThat(cursorFactory.exists(cursor2.getCursorId())).isTrue();
+        MongoKillCursors killCursors =
+            new MongoKillCursors(null, null, Collections.singletonList(cursor1.getCursorId()));
+        backend.handleKillCursors(killCursors);
+        assertThat(cursorFactory.exists(cursor1.getCursorId())).isFalse();
+        assertThat(cursorFactory.exists(cursor2.getCursorId())).isTrue();
+    }
+
+}

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoCollectionTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoCollectionTest.java
@@ -23,7 +23,7 @@ public class AbstractMongoCollectionTest {
     private static class TestCollection extends AbstractMongoCollection<Object> {
 
         TestCollection(MongoDatabase database, String collectionName) {
-            super(database, collectionName, CollectionOptions.withDefaults());
+            super(database, collectionName, CollectionOptions.withDefaults(), new CursorFactory());
         }
 
         @Override
@@ -147,15 +147,6 @@ public class AbstractMongoCollectionTest {
         assertThat(cursor.isEmpty()).isTrue();
         cursor = collection.createCursor(docs, 0, 0);
         assertThat(cursor.isEmpty()).isTrue();
-    }
-
-    @Test
-    void testGetMore_shouldDeleteCursorIfEmpty() {
-        Collection<Document> docs = Arrays.asList(new Document("name", "Joe"), new Document("name", "Mary"),
-            new Document("name", "Steve"));
-        Cursor cursor = collection.createCursor(docs, 0, 2);
-        collection.handleGetMore(cursor.getCursorId(), 1);
-        assertThat(collection.cursors.containsKey(cursor.getCursorId())).isFalse();
     }
 
 }

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupWithPipelineStageTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/LookupWithPipelineStageTest.java
@@ -3,6 +3,7 @@ package de.bwaldvogel.mongo.backend.aggregation.stage;
 import static de.bwaldvogel.mongo.TestUtils.json;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import de.bwaldvogel.mongo.oplog.NoopOplog;
 import org.junit.jupiter.api.Test;
 
 import de.bwaldvogel.mongo.exception.MongoServerException;
@@ -17,7 +18,7 @@ public class LookupWithPipelineStageTest extends AbstractLookupStageTest {
     }
 
     private void buildLookupStage(String jsonDocument) {
-        new LookupWithPipelineStage(json(jsonDocument), database);
+        new LookupWithPipelineStage(json(jsonDocument), database, NoopOplog.get());
     }
 
 }

--- a/h2-backend/src/main/java/de/bwaldvogel/mongo/backend/h2/H2Backend.java
+++ b/h2-backend/src/main/java/de/bwaldvogel/mongo/backend/h2/H2Backend.java
@@ -61,7 +61,7 @@ public class H2Backend extends AbstractMongoBackend {
 
     @Override
     protected MongoDatabase openOrCreateDatabase(String databaseName) {
-        return new H2Database(databaseName, this, mvStore);
+        return new H2Database(databaseName, this, mvStore, cursorFactory);
     }
 
     public MVStore getMvStore() {

--- a/h2-backend/src/main/java/de/bwaldvogel/mongo/backend/h2/H2Collection.java
+++ b/h2-backend/src/main/java/de/bwaldvogel/mongo/backend/h2/H2Collection.java
@@ -6,18 +6,12 @@ import java.util.NoSuchElementException;
 import java.util.UUID;
 import java.util.stream.Stream;
 
+import de.bwaldvogel.mongo.backend.*;
 import org.h2.mvstore.MVMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.bwaldvogel.mongo.MongoDatabase;
-import de.bwaldvogel.mongo.backend.AbstractSynchronizedMongoCollection;
-import de.bwaldvogel.mongo.backend.Assert;
-import de.bwaldvogel.mongo.backend.CollectionOptions;
-import de.bwaldvogel.mongo.backend.DocumentWithPosition;
-import de.bwaldvogel.mongo.backend.Missing;
-import de.bwaldvogel.mongo.backend.QueryResult;
-import de.bwaldvogel.mongo.backend.Utils;
 import de.bwaldvogel.mongo.bson.Document;
 
 public class H2Collection extends AbstractSynchronizedMongoCollection<Object> {

--- a/h2-backend/src/main/java/de/bwaldvogel/mongo/backend/h2/H2Collection.java
+++ b/h2-backend/src/main/java/de/bwaldvogel/mongo/backend/h2/H2Collection.java
@@ -30,8 +30,8 @@ public class H2Collection extends AbstractSynchronizedMongoCollection<Object> {
     private static final String DATA_SIZE_KEY = "dataSize";
 
     public H2Collection(MongoDatabase database, String collectionName, CollectionOptions options,
-                        MVMap<Object, Document> dataMap, MVMap<String, Object> metaMap) {
-        super(database, collectionName, options);
+                        MVMap<Object, Document> dataMap, MVMap<String, Object> metaMap, CursorFactory cursorFactory) {
+        super(database, collectionName, options, cursorFactory);
         this.dataMap = dataMap;
         this.metaMap = metaMap;
         if (!this.metaMap.containsKey(DATA_SIZE_KEY)) {

--- a/h2-backend/src/main/java/de/bwaldvogel/mongo/backend/h2/H2Database.java
+++ b/h2-backend/src/main/java/de/bwaldvogel/mongo/backend/h2/H2Database.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import de.bwaldvogel.mongo.backend.*;
 import org.h2.mvstore.FileStore;
 import org.h2.mvstore.MVMap;
 import org.h2.mvstore.MVStore;
@@ -13,11 +14,6 @@ import org.slf4j.LoggerFactory;
 import de.bwaldvogel.mongo.MongoBackend;
 import de.bwaldvogel.mongo.MongoCollection;
 import de.bwaldvogel.mongo.MongoDatabase;
-import de.bwaldvogel.mongo.backend.AbstractMongoDatabase;
-import de.bwaldvogel.mongo.backend.CollectionOptions;
-import de.bwaldvogel.mongo.backend.Index;
-import de.bwaldvogel.mongo.backend.IndexKey;
-import de.bwaldvogel.mongo.backend.KeyValue;
 import de.bwaldvogel.mongo.bson.Document;
 
 public class H2Database extends AbstractMongoDatabase<Object> {
@@ -29,8 +25,8 @@ public class H2Database extends AbstractMongoDatabase<Object> {
 
     private final MVStore mvStore;
 
-    public H2Database(String databaseName, MongoBackend backend, MVStore mvStore) {
-        super(databaseName);
+    public H2Database(String databaseName, MongoBackend backend, MVStore mvStore, CursorFactory cursorFactory) {
+        super(databaseName, cursorFactory);
         this.mvStore = mvStore;
         initializeNamespacesAndIndexes();
     }
@@ -75,7 +71,7 @@ public class H2Database extends AbstractMongoDatabase<Object> {
         String fullCollectionName = databaseName + "." + collectionName;
         MVMap<Object, Document> dataMap = mvStore.openMap(DATABASES_PREFIX + fullCollectionName);
         MVMap<String, Object> metaMap = mvStore.openMap(META_PREFIX + fullCollectionName);
-        return new H2Collection(this, collectionName, options, dataMap, metaMap);
+        return new H2Collection(this, collectionName, options, dataMap, metaMap, cursorFactory);
     }
 
     @Override

--- a/memory-backend/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryBackend.java
+++ b/memory-backend/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryBackend.java
@@ -6,7 +6,7 @@ public class MemoryBackend extends AbstractMongoBackend {
 
     @Override
     public MemoryDatabase openOrCreateDatabase(String databaseName) {
-        return new MemoryDatabase(this, databaseName);
+        return new MemoryDatabase(this, databaseName, cursorFactory);
     }
 
 }

--- a/memory-backend/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryCollection.java
+++ b/memory-backend/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryCollection.java
@@ -9,11 +9,7 @@ import java.util.stream.IntStream;
 import java.util.stream.Stream;
 
 import de.bwaldvogel.mongo.MongoDatabase;
-import de.bwaldvogel.mongo.backend.AbstractSynchronizedMongoCollection;
-import de.bwaldvogel.mongo.backend.CollectionOptions;
-import de.bwaldvogel.mongo.backend.DocumentComparator;
-import de.bwaldvogel.mongo.backend.DocumentWithPosition;
-import de.bwaldvogel.mongo.backend.QueryResult;
+import de.bwaldvogel.mongo.backend.*;
 import de.bwaldvogel.mongo.bson.Document;
 
 public class MemoryCollection extends AbstractSynchronizedMongoCollection<Integer> {

--- a/memory-backend/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryCollection.java
+++ b/memory-backend/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryCollection.java
@@ -22,8 +22,8 @@ public class MemoryCollection extends AbstractSynchronizedMongoCollection<Intege
     private final Queue<Integer> emptyPositions = new LinkedList<>();
     private final AtomicInteger dataSize = new AtomicInteger();
 
-    public MemoryCollection(MongoDatabase database, String collectionName, CollectionOptions options) {
-        super(database, collectionName, options);
+    public MemoryCollection(MongoDatabase database, String collectionName, CollectionOptions options, CursorFactory cursorFactory) {
+        super(database, collectionName, options, cursorFactory);
     }
 
     @Override

--- a/memory-backend/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryDatabase.java
+++ b/memory-backend/src/main/java/de/bwaldvogel/mongo/backend/memory/MemoryDatabase.java
@@ -3,22 +3,19 @@ package de.bwaldvogel.mongo.backend.memory;
 import java.util.List;
 
 import de.bwaldvogel.mongo.MongoBackend;
-import de.bwaldvogel.mongo.backend.AbstractMongoDatabase;
-import de.bwaldvogel.mongo.backend.CollectionOptions;
-import de.bwaldvogel.mongo.backend.Index;
-import de.bwaldvogel.mongo.backend.IndexKey;
+import de.bwaldvogel.mongo.backend.*;
 import de.bwaldvogel.mongo.backend.memory.index.MemoryUniqueIndex;
 
 public class MemoryDatabase extends AbstractMongoDatabase<Integer> {
 
-    public MemoryDatabase(MongoBackend backend, String databaseName) {
-        super(databaseName);
+    public MemoryDatabase(MongoBackend backend, String databaseName, CursorFactory cursorFactory) {
+        super(databaseName, cursorFactory);
         initializeNamespacesAndIndexes();
     }
 
     @Override
     protected MemoryCollection openOrCreateCollection(String collectionName, CollectionOptions options) {
-        return new MemoryCollection(this, collectionName, options);
+        return new MemoryCollection(this, collectionName, options, cursorFactory);
     }
 
     @Override

--- a/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlBackend.java
+++ b/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlBackend.java
@@ -35,7 +35,7 @@ public class PostgresqlBackend extends AbstractMongoBackend {
             throw new MongoServerException("failed to open or create database", e);
         }
 
-        return new PostgresqlDatabase(databaseName, this);
+        return new PostgresqlDatabase(databaseName, this, cursorFactory);
     }
 
     public Connection getConnection() throws SQLException {

--- a/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlCollection.java
+++ b/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlCollection.java
@@ -23,8 +23,8 @@ public class PostgresqlCollection extends AbstractSynchronizedMongoCollection<Lo
 
     private final PostgresqlBackend backend;
 
-    public PostgresqlCollection(PostgresqlDatabase database, String collectionName, CollectionOptions options) {
-        super(database, collectionName, options);
+    public PostgresqlCollection(PostgresqlDatabase database, String collectionName, CollectionOptions options, CursorFactory cursorFactory) {
+        super(database, collectionName, options, cursorFactory);
         this.backend = database.getBackend();
     }
 

--- a/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlCollection.java
+++ b/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlCollection.java
@@ -11,10 +11,7 @@ import java.util.Objects;
 import java.util.stream.Stream;
 
 import de.bwaldvogel.mongo.MongoDatabase;
-import de.bwaldvogel.mongo.backend.AbstractSynchronizedMongoCollection;
-import de.bwaldvogel.mongo.backend.CollectionOptions;
-import de.bwaldvogel.mongo.backend.DocumentWithPosition;
-import de.bwaldvogel.mongo.backend.QueryResult;
+import de.bwaldvogel.mongo.backend.*;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.exception.DuplicateKeyError;
 import de.bwaldvogel.mongo.exception.MongoServerException;

--- a/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlDatabase.java
+++ b/postgresql-backend/src/main/java/de/bwaldvogel/mongo/backend/postgresql/PostgresqlDatabase.java
@@ -6,10 +6,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import de.bwaldvogel.mongo.MongoCollection;
-import de.bwaldvogel.mongo.backend.AbstractMongoDatabase;
-import de.bwaldvogel.mongo.backend.CollectionOptions;
-import de.bwaldvogel.mongo.backend.Index;
-import de.bwaldvogel.mongo.backend.IndexKey;
+import de.bwaldvogel.mongo.backend.*;
 import de.bwaldvogel.mongo.backend.postgresql.index.PostgresUniqueIndex;
 import de.bwaldvogel.mongo.exception.MongoServerException;
 
@@ -17,8 +14,8 @@ public class PostgresqlDatabase extends AbstractMongoDatabase<Long> {
 
     private final PostgresqlBackend backend;
 
-    public PostgresqlDatabase(String databaseName, PostgresqlBackend backend) {
-        super(databaseName);
+    public PostgresqlDatabase(String databaseName, PostgresqlBackend backend, CursorFactory cursorFactory) {
+        super(databaseName, cursorFactory);
         this.backend = backend;
         initializeNamespacesAndIndexes();
     }
@@ -87,7 +84,7 @@ public class PostgresqlDatabase extends AbstractMongoDatabase<Long> {
             throw new MongoServerException("failed to create or open collection " + collectionName, e);
         }
 
-        return new PostgresqlCollection(this, collectionName, options);
+        return new PostgresqlCollection(this, collectionName, options, cursorFactory);
     }
 
     public PostgresqlBackend getBackend() {

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/TestClock.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/TestClock.java
@@ -1,48 +1,24 @@
 package de.bwaldvogel.mongo.backend;
 
 import java.time.Clock;
-import java.time.Duration;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 
-public class TestClock extends Clock {
+public class TestClock extends MongoBackendClock {
 
     private static final Instant DEFAULT_INSTANT = Instant.parse("2019-05-23T12:00:00.123Z");
 
-    private Instant instant;
-    private final ZoneId zone;
-
     private TestClock(Instant instant, ZoneId zone) {
-        this.zone = zone;
-        this.instant = instant;
+        super(Clock.fixed(instant, zone));
     }
 
     public static TestClock defaultClock() {
         return new TestClock(DEFAULT_INSTANT, ZoneOffset.UTC);
     }
 
-    @Override
-    public ZoneId getZone() {
-        return zone;
-    }
-
-    @Override
-    public Clock withZone(ZoneId zone) {
-        return new TestClock(instant, zone);
-    }
-
-    @Override
-    public Instant instant() {
-        return instant;
-    }
-
-    public void windForward(Duration duration) {
-        instant = instant.plus(duration);
-    }
-
     public void reset() {
-        instant = DEFAULT_INSTANT;
+        super.reset(DEFAULT_INSTANT);
     }
 
 }


### PR DESCRIPTION
Handling cursors at the backend level.
Creating tailable cursors
Implementing the changeStream stage of the Aggregation pipeline, using the oplog for this purpose.
Replace the old clock with MongoBackendClock. A wrapper around a java.time.Clock plus an increment. This is needed for the resume token on change stream.
Change stream update full document lookup.
Making test clock inherit from mongo backend clock so the reset method takes into account the increment.
Adding documentKey field to the change streams response.
Implementing and testing change stream on updates and deletes.