### PR TITLE
Support projecting out with nested values

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/Projection.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/Projection.java
@@ -10,7 +10,6 @@ import java.util.stream.Collectors;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.exception.BadValueException;
 
-import javax.print.Doc;
 
 class Projection {
 
@@ -22,9 +21,6 @@ class Projection {
         validateFields(fields);
         this.fields = fields;
         this.idField = idField;
-
-
-
         this.onlyExclusions = onlyExclusions(fields);
     }
 

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/Projection.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/Projection.java
@@ -3,10 +3,14 @@ package de.bwaldvogel.mongo.backend;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.stream.Collectors;
 
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.exception.BadValueException;
+
+import javax.print.Doc;
 
 class Projection {
 
@@ -18,6 +22,9 @@ class Projection {
         validateFields(fields);
         this.fields = fields;
         this.idField = idField;
+
+
+
         this.onlyExclusions = onlyExclusions(fields);
     }
 
@@ -36,17 +43,12 @@ class Projection {
 
         if (onlyExclusions) {
             newDocument.putAll(document);
-            for (String excludedField : fields.keySet()) {
-                newDocument.remove(excludedField);
-            }
-        } else {
-            for (Entry<String, Object> entry : fields.entrySet()) {
-                String key = entry.getKey();
-                Object value = entry.getValue();
-                if (Utils.isTrue(value)) {
-                    projectField(document, newDocument, key, value);
-                }
-            }
+        }
+
+        for (Entry<String, Object> entry : fields.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            projectField(document, newDocument, key, value);
         }
 
         return newDocument;
@@ -64,13 +66,24 @@ class Projection {
         }
     }
 
-    private static boolean onlyExclusions(Document fields) {
-        for (String key : fields.keySet()) {
-            if (Utils.isTrue(fields.get(key))) {
-                return false;
-            }
+    private boolean onlyExclusions(Document fields) {
+
+        Map<Boolean, Long> result = fields.entrySet().stream()
+            //Special case: if the idField is to be excluded that's always ok:
+            .filter(entry->!(entry.getKey().equals(idField) && !Utils.isTrue(entry.getValue())))
+            .collect(Collectors.partitioningBy(
+                entry -> Utils.isTrue(fields.get(entry.getKey())),
+                Collectors.counting()
+            ));
+
+        //Mongo will police that all the entries are inclusions or exclusions.
+        long inclusions = result.get(true);
+        long exclusions = result.get(false);
+
+        if(inclusions > 0 && exclusions > 0) {
+            throw new BadValueException("Projections cannot have a mix of inclusion and exclusions");
         }
-        return true;
+        return exclusions>0;
     }
 
     private static void projectField(Document document, Document newDocument, String key, Object projectionValue) {
@@ -87,26 +100,38 @@ class Projection {
                 projectField((Document) object, subDocument, subKey, projectionValue);
             } else if (object instanceof List) {
                 List<?> values = (List<?>) object;
-                List<Document> projectedValues = (List<Document>) newDocument.computeIfAbsent(mainKey, k -> new ArrayList<>());
-                boolean wasEmpty = projectedValues.isEmpty();
-                int idx = 0;
+                List<Object> projectedValues = (List<Object>) newDocument.computeIfAbsent(mainKey, k -> new ArrayList<>());
 
                 if ("$".equals(subKey) && !values.isEmpty()) {
                     Object firstValue = values.get(0);
                     if (firstValue instanceof Document) {
-                        projectedValues.add((Document) firstValue);
+                        projectedValues.add(firstValue);
                     }
                 } else {
+                    if(projectedValues.isEmpty()) {
+                        //In this case we're projecting in, so start with empty documents:
+                        for (Object value : values) {
+                            if (value instanceof Document) {
+                                projectedValues.add(new Document());
+                            } //Primatives can never be projected-in.
+                        }
+                    }
+
+                    //Now loop over the underlying values and project
+                    int idx = 0;
                     for (Object value : values) {
                         if (value instanceof Document) {
                             final Document projectedDocument;
-                            if (wasEmpty) {
-                                projectedDocument = new Document();
-                                projectedValues.add(projectedDocument);
-                            } else {
-                                projectedDocument = projectedValues.get(idx);
-                            }
+
+                            //If this fails it means the newDocument's list differs from the oldDocuments list
+                            projectedDocument = (Document)projectedValues.get(idx);
+
                             projectField((Document) value, projectedDocument, subKey, projectionValue);
+                            idx++;
+                        }
+                        //Bit of a kludge here: if we're projecting in then we need to count only the Document instances
+                        //but if we're projecting away we need to count everything.
+                        else if(!Utils.isTrue(projectionValue)) {
                             idx++;
                         }
                     }
@@ -126,8 +151,14 @@ class Projection {
                 } else {
                     throw new IllegalArgumentException("Unsupported projection: " + projectionValue);
                 }
-            } else if (!(value instanceof Missing)) {
-                newDocument.put(key, value);
+            } else {
+                if (Utils.isTrue(projectionValue)) {
+                    if(!(value instanceof Missing)) {
+                        newDocument.put(key, value);
+                    }
+                } else {
+                    newDocument.remove(key);
+                }
             }
         }
     }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/Projection.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/Projection.java
@@ -77,7 +77,7 @@ class Projection {
         long exclusions = result.get(false);
 
         if(inclusions > 0 && exclusions > 0) {
-            throw new BadValueException("Projections cannot have a mix of inclusion and exclusions");
+            throw new BadValueException("Projections cannot have a mix of inclusion and exclusion.");
         }
         return !(inclusions>0);
     }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/Projection.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/Projection.java
@@ -79,7 +79,7 @@ class Projection {
         if(inclusions > 0 && exclusions > 0) {
             throw new BadValueException("Projections cannot have a mix of inclusion and exclusions");
         }
-        return exclusions>0;
+        return !(inclusions>0);
     }
 
     private static void projectField(Document document, Document newDocument, String key, Object projectionValue) {

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/ProjectionTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/ProjectionTest.java
@@ -24,6 +24,9 @@ public class ProjectionTest {
         assertThat(projectDocument(json("_id: 100, foo: 123"), json("_id: 1"), "_id"))
             .isEqualTo(json("_id: 100"));
 
+        assertThat(projectDocument(json("_id: 100, foo: 123"), json("_id: 0"), "_id"))
+            .isEqualTo(json("foo: 123"));
+
         assertThat(projectDocument(json("_id: 100, foo: 123"), json("_id: 0, foo: 1"), "_id"))
             .isEqualTo(json("foo: 123"));
 

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
+import org.assertj.core.api.Assertions;
 import org.bson.BsonInt32;
 import org.bson.BsonJavaScript;
 import org.bson.BsonObjectId;
@@ -4168,8 +4169,11 @@ public abstract class AbstractBackendTest extends AbstractTest {
         Document obj = json("_id: 1, order:1, visits: 2, eid: 12345");
         collection.insertOne(obj);
 
-        Document document = collection.find(new Document()).projection(json("visits: 0, eid: 1")).first();
-        assertThat(document).isEqualTo(json("_id: 1, eid: 12345"));
+        //When I try this on actual mongo I get an error!
+        Assertions.assertThatExceptionOfType(MongoQueryException.class)
+            .isThrownBy(
+                ()-> collection.find(new Document()).projection(json("visits: 0, eid: 1")).first()
+            ).withMessageContaining("Projections cannot have a mix of inclusion and exclusion");
     }
 
     @Test


### PR DESCRIPTION
For example: `{'foo.bar': 0}` should project away any `bar` inside `foo`.