### PR TITLE
Add async support

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/AsyncMongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/AsyncMongoBackend.java
@@ -1,0 +1,39 @@
+package de.bwaldvogel.mongo;
+
+import java.util.concurrent.CompletionStage;
+
+import de.bwaldvogel.mongo.backend.QueryResult;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.wire.message.MongoDelete;
+import de.bwaldvogel.mongo.wire.message.MongoGetMore;
+import de.bwaldvogel.mongo.wire.message.MongoInsert;
+import de.bwaldvogel.mongo.wire.message.MongoKillCursors;
+import de.bwaldvogel.mongo.wire.message.MongoMessage;
+import de.bwaldvogel.mongo.wire.message.MongoQuery;
+import de.bwaldvogel.mongo.wire.message.MongoUpdate;
+import io.netty.channel.Channel;
+
+public interface AsyncMongoBackend {
+
+    CompletionStage<Void> handleCloseAsync(Channel channel);
+
+    CompletionStage<Document> handleCommandAsync(Channel channel, String database, String command, Document query);
+
+    CompletionStage<QueryResult> handleQueryAsync(MongoQuery query);
+
+    CompletionStage<QueryResult> handleGetMoreAsync(MongoGetMore getMore);
+
+    CompletionStage<Void> handleInsertAsync(MongoInsert insert);
+
+    CompletionStage<Void> handleDeleteAsync(MongoDelete delete);
+
+    CompletionStage<Void> handleUpdateAsync(MongoUpdate update);
+
+    CompletionStage<Void> handleKillCursorsAsync(MongoKillCursors mongoKillCursors);
+
+    CompletionStage<Document> handleMessageAsync(MongoMessage message);
+
+    CompletionStage<Void> dropDatabaseAsync(String database);
+
+    CompletionStage<Void> closeAsync();
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/AsyncMongoCollection.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/AsyncMongoCollection.java
@@ -1,0 +1,11 @@
+package de.bwaldvogel.mongo;
+
+import java.util.concurrent.CompletionStage;
+
+import de.bwaldvogel.mongo.backend.QueryResult;
+import de.bwaldvogel.mongo.bson.Document;
+
+public interface AsyncMongoCollection {
+
+    CompletionStage<QueryResult> handleQueryAsync(Document query, int numberToSkip, int limit, int batchSize, Document returnFieldSelector);
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/AsyncMongoDatabase.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/AsyncMongoDatabase.java
@@ -1,0 +1,25 @@
+package de.bwaldvogel.mongo;
+
+import java.util.concurrent.CompletionStage;
+
+import de.bwaldvogel.mongo.backend.QueryResult;
+import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.oplog.Oplog;
+import de.bwaldvogel.mongo.wire.message.MongoDelete;
+import de.bwaldvogel.mongo.wire.message.MongoInsert;
+import de.bwaldvogel.mongo.wire.message.MongoQuery;
+import de.bwaldvogel.mongo.wire.message.MongoUpdate;
+import io.netty.channel.Channel;
+
+public interface AsyncMongoDatabase {
+
+    CompletionStage<Document> handleCommandAsync(Channel channel, String command, Document query, Oplog oplog);
+
+    CompletionStage<QueryResult> handleQueryAsync(MongoQuery query);
+
+    CompletionStage<Void> handleInsertAsync(MongoInsert insert, Oplog oplog);
+
+    CompletionStage<Void> handleDeleteAsync(MongoDelete delete, Oplog oplog);
+
+    CompletionStage<Void> handleUpdateAsync(MongoUpdate update, Oplog oplog);
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
@@ -2,9 +2,11 @@ package de.bwaldvogel.mongo;
 
 import java.time.Clock;
 import java.util.Collection;
+import java.util.concurrent.CompletionStage;
 
 import de.bwaldvogel.mongo.backend.QueryResult;
 import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.util.FutureUtils;
 import de.bwaldvogel.mongo.wire.message.MongoDelete;
 import de.bwaldvogel.mongo.wire.message.MongoGetMore;
 import de.bwaldvogel.mongo.wire.message.MongoInsert;
@@ -14,35 +16,111 @@ import de.bwaldvogel.mongo.wire.message.MongoQuery;
 import de.bwaldvogel.mongo.wire.message.MongoUpdate;
 import io.netty.channel.Channel;
 
-public interface MongoBackend {
+public interface MongoBackend extends AsyncMongoBackend {
 
     void handleClose(Channel channel);
 
+    @Override
+    default CompletionStage<Void> handleCloseAsync(Channel channel) {
+        return FutureUtils.wrap(() -> {
+            handleClose(channel);
+            return null;
+        });
+    }
+
     Document handleCommand(Channel channel, String database, String command, Document query);
 
+    @Override
+    default CompletionStage<Document> handleCommandAsync(Channel channel, String database, String command, Document query) {
+        return FutureUtils.wrap(() -> handleCommand(channel, database, command, query));
+    }
+
     QueryResult handleQuery(MongoQuery query);
+
+    @Override
+    default CompletionStage<QueryResult> handleQueryAsync(MongoQuery query) {
+        return FutureUtils.wrap(() -> handleQuery(query));
+    }
 
     QueryResult handleGetMore(long cursorId, int numberToReturn);
 
     QueryResult handleGetMore(MongoGetMore getMore);
 
+    @Override
+    default CompletionStage<QueryResult> handleGetMoreAsync(MongoGetMore getMore) {
+        return FutureUtils.wrap(() -> handleGetMore(getMore));
+    }
+
     void handleInsert(MongoInsert insert);
+
+    @Override
+    default CompletionStage<Void> handleInsertAsync(MongoInsert insert) {
+        return FutureUtils.wrap(() -> {
+            handleInsert(insert);
+            return null;
+        });
+    }
 
     void handleDelete(MongoDelete delete);
 
+    @Override
+    default CompletionStage<Void> handleDeleteAsync(MongoDelete delete) {
+        return FutureUtils.wrap(() -> {
+            handleDelete(delete);
+            return null;
+        });
+    }
+
     void handleUpdate(MongoUpdate update);
+
+    @Override
+    default CompletionStage<Void> handleUpdateAsync(MongoUpdate update) {
+        return FutureUtils.wrap(() -> {
+            handleUpdate(update);
+            return null;
+        });
+    }
 
     void handleKillCursors(MongoKillCursors mongoKillCursors);
 
+    @Override
+    default CompletionStage<Void> handleKillCursorsAsync(MongoKillCursors mongoKillCursors) {
+        return FutureUtils.wrap(() -> {
+            handleKillCursors(mongoKillCursors);
+            return null;
+        });
+    }
+
     Document handleMessage(MongoMessage message);
 
+    @Override
+    default CompletionStage<Document> handleMessageAsync(MongoMessage message) {
+        return FutureUtils.wrap(() -> handleMessage(message));
+    }
+
     void dropDatabase(String database);
+
+    @Override
+    default CompletionStage<Void> dropDatabaseAsync(String database) {
+        return FutureUtils.wrap(() -> {
+            dropDatabase(database);
+            return null;
+        });
+    }
 
     Collection<Document> getCurrentOperations(MongoQuery query);
 
     Document getServerStatus();
 
     void close();
+
+    @Override
+    default CompletionStage<Void> closeAsync() {
+        return FutureUtils.wrap(() -> {
+            close();
+            return null;
+        });
+    }
 
     Clock getClock();
 

--- a/core/src/main/java/de/bwaldvogel/mongo/MongoCollection.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoCollection.java
@@ -2,6 +2,7 @@ package de.bwaldvogel.mongo;
 
 import java.util.List;
 import java.util.Spliterator;
+import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -11,8 +12,9 @@ import de.bwaldvogel.mongo.backend.QueryResult;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.oplog.NoopOplog;
 import de.bwaldvogel.mongo.oplog.Oplog;
+import de.bwaldvogel.mongo.util.FutureUtils;
 
-public interface MongoCollection<P> {
+public interface MongoCollection<P> extends AsyncMongoCollection {
 
     MongoDatabase getDatabase();
 
@@ -64,8 +66,13 @@ public interface MongoCollection<P> {
 
     QueryResult handleQuery(Document query, int numberToSkip, int limit, int batchSize, Document returnFieldSelector);
 
-    default void insertDocuments(List<Document> documents) {
-        insertDocuments(documents, true);
+    @Override
+    default CompletionStage<QueryResult> handleQueryAsync(Document query, int numberToSkip, int limit, int batchSize, Document returnFieldSelector) {
+        return FutureUtils.wrap(() -> handleQuery(query, numberToSkip, limit, batchSize, returnFieldSelector));
+    }
+
+    default List<Document> insertDocuments(List<Document> documents) {
+        return insertDocuments(documents, true);
     }
 
     List<Document> insertDocuments(List<Document> documents, boolean isOrdered);

--- a/core/src/main/java/de/bwaldvogel/mongo/MongoDatabase.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoDatabase.java
@@ -1,16 +1,19 @@
 package de.bwaldvogel.mongo;
 
+import java.util.concurrent.CompletionStage;
+
 import de.bwaldvogel.mongo.backend.CollectionOptions;
 import de.bwaldvogel.mongo.backend.QueryResult;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.oplog.Oplog;
+import de.bwaldvogel.mongo.util.FutureUtils;
 import de.bwaldvogel.mongo.wire.message.MongoDelete;
 import de.bwaldvogel.mongo.wire.message.MongoInsert;
 import de.bwaldvogel.mongo.wire.message.MongoQuery;
 import de.bwaldvogel.mongo.wire.message.MongoUpdate;
 import io.netty.channel.Channel;
 
-public interface MongoDatabase {
+public interface MongoDatabase extends AsyncMongoDatabase {
 
     String getDatabaseName();
 
@@ -18,13 +21,47 @@ public interface MongoDatabase {
 
     Document handleCommand(Channel channel, String command, Document query, Oplog oplog);
 
+    @Override
+    default CompletionStage<Document> handleCommandAsync(Channel channel, String command, Document query, Oplog oplog) {
+        return FutureUtils.wrap(() -> handleCommand(channel, command, query, oplog));
+    }
+
     QueryResult handleQuery(MongoQuery query);
+
+    @Override
+    default CompletionStage<QueryResult> handleQueryAsync(MongoQuery query) {
+        return FutureUtils.wrap(() -> handleQuery(query));
+    }
 
     void handleInsert(MongoInsert insert, Oplog oplog);
 
+    @Override
+    default CompletionStage<Void> handleInsertAsync(MongoInsert insert, Oplog oplog) {
+        return FutureUtils.wrap(() -> {
+            handleInsert(insert, oplog);
+            return null;
+        });
+    }
+
     void handleDelete(MongoDelete delete, Oplog oplog);
 
+    @Override
+    default CompletionStage<Void> handleDeleteAsync(MongoDelete delete, Oplog oplog) {
+        return FutureUtils.wrap(() -> {
+            handleDelete(delete, oplog);
+            return null;
+        });
+    }
+
     void handleUpdate(MongoUpdate update, Oplog oplog);
+
+    @Override
+    default CompletionStage<Void> handleUpdateAsync(MongoUpdate update, Oplog oplog) {
+        return FutureUtils.wrap(() -> {
+            handleUpdate(update, oplog);
+            return null;
+        });
+    }
 
     boolean isEmpty();
 

--- a/core/src/main/java/de/bwaldvogel/mongo/util/FutureUtils.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/util/FutureUtils.java
@@ -1,0 +1,20 @@
+package de.bwaldvogel.mongo.util;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Supplier;
+
+public class FutureUtils {
+    public static <T> CompletableFuture<T> wrap(Supplier<T> supplier) {
+        try {
+            return CompletableFuture.completedFuture(supplier.get());
+        } catch (Throwable t) {
+            return failedFuture(t);
+        }
+    }
+
+    public static <T> CompletableFuture<T> failedFuture(Throwable cause) {
+        CompletableFuture<T> future = new CompletableFuture<>();
+        future.completeExceptionally(cause);
+        return future;
+    }
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/wire/MongoDatabaseHandler.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/wire/MongoDatabaseHandler.java
@@ -1,10 +1,8 @@
 package de.bwaldvogel.mongo.wire;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
@@ -18,6 +16,7 @@ import de.bwaldvogel.mongo.exception.CursorNotFoundException;
 import de.bwaldvogel.mongo.exception.MongoServerError;
 import de.bwaldvogel.mongo.exception.MongoServerException;
 import de.bwaldvogel.mongo.exception.NoSuchCommandException;
+import de.bwaldvogel.mongo.util.FutureUtils;
 import de.bwaldvogel.mongo.wire.message.ClientRequest;
 import de.bwaldvogel.mongo.wire.message.MessageHeader;
 import de.bwaldvogel.mongo.wire.message.MongoDelete;
@@ -57,106 +56,156 @@ public class MongoDatabaseHandler extends SimpleChannelInboundHandler<ClientRequ
     public void channelInactive(ChannelHandlerContext ctx) throws Exception {
         log.info("channel {} closed", ctx.channel());
         channelGroup.remove(ctx.channel());
-        mongoBackend.handleClose(ctx.channel());
-        super.channelInactive(ctx);
+        mongoBackend.handleCloseAsync(ctx.channel())
+            .thenAcceptAsync(aVoid -> {
+                    try {
+                        super.channelInactive(ctx);
+                    } catch (Exception e) {
+                        ctx.fireExceptionCaught(e);
+                    }
+                },
+                ctx.executor());
     }
 
     @Override
     protected void channelRead0(ChannelHandlerContext ctx, ClientRequest object) {
         if (object instanceof MongoQuery) {
-            MongoQuery mongoQuery = (MongoQuery) object;
-            ctx.channel().writeAndFlush(handleQuery(mongoQuery));
+            handleQueryAsync((MongoQuery) object).thenAccept(response ->
+                ctx.channel().writeAndFlush(response));
         } else if (object instanceof MongoInsert) {
-            MongoInsert insert = (MongoInsert) object;
-            mongoBackend.handleInsert(insert);
+            mongoBackend.handleInsertAsync((MongoInsert) object);
         } else if (object instanceof MongoDelete) {
-            MongoDelete delete = (MongoDelete) object;
-            mongoBackend.handleDelete(delete);
+            mongoBackend.handleDeleteAsync((MongoDelete) object);
         } else if (object instanceof MongoUpdate) {
-            MongoUpdate update = (MongoUpdate) object;
-            mongoBackend.handleUpdate(update);
+            mongoBackend.handleUpdateAsync((MongoUpdate) object);
         } else if (object instanceof MongoGetMore) {
-            MongoGetMore getMore = (MongoGetMore) object;
-            ctx.channel().writeAndFlush(handleGetMore(getMore));
+            handleGetMoreAsync((MongoGetMore) object).thenAccept(response ->
+                ctx.channel().writeAndFlush(response));
         } else if (object instanceof MongoKillCursors) {
-            handleKillCursors((MongoKillCursors) object);
+            mongoBackend.handleKillCursorsAsync((MongoKillCursors) object);
         } else if (object instanceof MongoMessage) {
-            MongoMessage message = (MongoMessage) object;
-            ctx.channel().writeAndFlush(handleMessage(message));
+            handleMessageAsync((MongoMessage) object).thenAccept(response ->
+                ctx.channel().writeAndFlush(response));
         } else {
             throw new MongoServerException("unknown message: " + object);
         }
     }
 
-    private MongoMessage handleMessage(MongoMessage message) {
-        Document document;
-        try {
-            document = mongoBackend.handleMessage(message);
-        } catch (MongoServerException e) {
+    // visible for testing
+    CompletionStage<MongoMessage> handleMessageAsync(MongoMessage message) {
+        return mongoBackend.handleMessageAsync(message)
+            .handle((document, ex) -> createResponseMongoMessage(message, document, ex));
+    }
+
+    private MongoMessage createResponseMongoMessage(MongoMessage message, Document document, Throwable ex) {
+        if (ex != null) {
+            MongoServerException e;
+            if (!(ex instanceof MongoServerException)) {
+                e = new MongoServerException("Unknown error: " + ex.getMessage(), ex);
+            } else {
+                e = (MongoServerException) ex;
+            }
+
             if (e.isLogError()) {
                 log.error("failed to handle {}", message.getDocument(), e);
             }
+
             document = errorResponse(e, Collections.emptyMap());
         }
-        MessageHeader header = createResponseHeader(message);
-        return new MongoMessage(message.getChannel(), header, document);
+        return new MongoMessage(message.getChannel(), createResponseHeader(message), document);
     }
 
-    private MongoReply handleQuery(MongoQuery query) {
+    // visible for testing
+    CompletionStage<MongoReply> handleQueryAsync(MongoQuery query) {
+        if (query.getCollectionName().startsWith("$cmd")) {
+            return handleCommandAsync(query)
+                .handle((document, ex) ->
+                    createResponseMongoReplyForCommand(query, document, ex));
+        }
+
+        return mongoBackend.handleQueryAsync(query)
+            .handle((queryResult, ex) ->
+                createResponseMongoReplyForQuery(query, queryResult, ex));
+    }
+
+    private MongoReply createResponseMongoReplyForCommand(MongoQuery query, Document document, Throwable t) {
         MessageHeader header = createResponseHeader(query);
-        try {
-            QueryResult queryResult = null;
-            List<Document> documents = new ArrayList<>();
-            if (query.getCollectionName().startsWith("$cmd")) {
-                documents.add(handleCommand(query));
-            } else {
-                queryResult = mongoBackend.handleQuery(query);
-                documents.addAll(queryResult.collectDocuments());
-            }
-            return new MongoReply(header, documents, queryResult == null ? 0 : queryResult.getCursorId());
-        } catch (NoSuchCommandException e) {
-            log.error("unknown command: {}", query, e);
+        if (t != null) {
+            return createResponseMongoReplyForQueryFailure(header, query, t);
+        }
+
+        return new MongoReply(header,
+            document != null ? Collections.singletonList(document) : Collections.emptyList(),
+            0);
+    }
+
+    private MongoReply createResponseMongoReplyForQuery(MongoQuery query, QueryResult queryResult, Throwable t) {
+        MessageHeader header = createResponseHeader(query);
+        if (t != null) {
+            return createResponseMongoReplyForQueryFailure(header, query, t);
+        }
+
+        return new MongoReply(header,
+            queryResult != null ? queryResult.collectDocuments() : Collections.emptyList(),
+            queryResult != null ? queryResult.getCursorId() : 0);
+    }
+
+    private MongoReply createResponseMongoReplyForQueryFailure(MessageHeader header, MongoQuery query, Throwable t) {
+        if (t instanceof NoSuchCommandException) {
+            log.error("unknown command: {}", query, t);
             Map<String, ?> additionalInfo = Collections.singletonMap("bad cmd", query.getQuery());
-            return queryFailure(header, e, additionalInfo);
-        } catch (MongoServerException e) {
-            if (e.isLogError()) {
-                log.error("failed to handle query {}", query, e);
+
+            return queryFailure(header, (NoSuchCommandException) t, additionalInfo);
+        } else if (t instanceof MongoServerException) {
+            if (((MongoServerException) t).isLogError()) {
+                log.error("failed to handle query {}", query, t);
             }
-            return queryFailure(header, e);
+
+            return queryFailure(header, (MongoServerException) t, Collections.emptyMap());
         }
+
+        return queryFailure(header,
+            new MongoServerException("Unknown error: " + t.getMessage(), t),
+            Collections.emptyMap());
     }
 
-    public MongoReply handleGetMore(MongoGetMore getMore) {
-        MessageHeader header = new MessageHeader(idSequence.incrementAndGet(), getMore.getHeader().getRequestID());
-        List<Document> documents = new ArrayList<>();
-        final QueryResult queryResult;
-        try {
-            queryResult = mongoBackend.handleGetMore(getMore);
-        } catch (CursorNotFoundException cursorNotFoundException) {
-            return new MongoReply(header, documents, getMore.getCursorId(), ReplyFlag.CURSOR_NOT_FOUND);
-        }
-        for (Document obj : queryResult) {
-            documents.add(obj);
-        }
-        return new MongoReply(header, documents, queryResult.getCursorId());
+    // visible for testing
+    CompletionStage<MongoReply> handleGetMoreAsync(MongoGetMore getMore) {
+        return mongoBackend.handleGetMoreAsync(getMore)
+            .handle((queryResult, ex) ->
+                createResponseMongoReplyForGetMore(getMore, queryResult, ex));
     }
 
-    public void handleKillCursors(MongoKillCursors mongoKillCursors) {
-        mongoBackend.handleKillCursors(mongoKillCursors);
+    private MongoReply createResponseMongoReplyForGetMore(MongoGetMore getMore, QueryResult queryResult, Throwable t) {
+        MessageHeader header = createResponseHeader(getMore);
+        if (t != null) {
+            return createResponseMongoReplyForGetMoreFailure(header, getMore, t);
+        }
+
+        return new MongoReply(header,
+            queryResult != null ? queryResult.collectDocuments() : Collections.emptyList(),
+            queryResult != null ? queryResult.getCursorId() : 0);
+    }
+
+    private MongoReply createResponseMongoReplyForGetMoreFailure(MessageHeader header, MongoGetMore getMore, Throwable t) {
+        if (t instanceof CursorNotFoundException) {
+            return new MongoReply(header,
+                Collections.emptyList(),
+                getMore != null ? getMore.getCursorId() : 0,
+                ReplyFlag.CURSOR_NOT_FOUND);
+        }
+
+        return queryFailure(header,
+            new MongoServerException("Unknown error: " + t.getMessage(), t),
+            Collections.emptyMap());
     }
 
     private MessageHeader createResponseHeader(ClientRequest request) {
         return new MessageHeader(idSequence.incrementAndGet(), request.getHeader().getRequestID());
     }
 
-    private MongoReply queryFailure(MessageHeader header, MongoServerException exception) {
-        Map<String, ?> additionalInfo = Collections.emptyMap();
-        return queryFailure(header, exception, additionalInfo);
-    }
-
     private MongoReply queryFailure(MessageHeader header, MongoServerException exception, Map<String, ?> additionalInfo) {
-        Document obj = errorResponse(exception, additionalInfo);
-        return new MongoReply(header, obj, ReplyFlag.QUERY_FAILURE);
+        return new MongoReply(header, errorResponse(exception, additionalInfo), ReplyFlag.QUERY_FAILURE);
     }
 
     private Document errorResponse(MongoServerException exception, Map<String, ?> additionalInfo) {
@@ -173,37 +222,42 @@ public class MongoDatabaseHandler extends SimpleChannelInboundHandler<ClientRequ
         return obj;
     }
 
-    Document handleCommand(MongoQuery query) {
+    // visible for testing
+    CompletionStage<Document> handleCommandAsync(MongoQuery query) {
         String collectionName = query.getCollectionName();
-        if (collectionName.equals("$cmd.sys.inprog")) {
-            Collection<Document> currentOperations = mongoBackend.getCurrentOperations(query);
-            return new Document("inprog", currentOperations);
-        }
 
-        if (collectionName.equals("$cmd")) {
+        if ("$cmd.sys.inprog".equals(collectionName)) {
+            return FutureUtils.wrap(() -> mongoBackend.getCurrentOperations(query))
+                .thenApply(currentOperations -> new Document("inprog", currentOperations));
+
+        } else if ("$cmd".equals(collectionName)) {
             String command = query.getQuery().keySet().iterator().next();
 
             switch (command) {
                 case "serverStatus":
-                    return mongoBackend.getServerStatus();
+                    return FutureUtils.wrap(mongoBackend::getServerStatus);
+
                 case "ping":
-                    Document response = new Document();
-                    Utils.markOkay(response);
-                    return response;
+                    return FutureUtils.wrap(() -> {
+                        Document response = new Document();
+                        Utils.markOkay(response);
+                        return response;
+                    });
+
                 default:
                     Document actualQuery = query.getQuery();
-
-                    if (command.equals("$query")) {
+                    if ("$query".equals(command)) {
                         command = ((Document) query.getQuery().get("$query")).keySet().iterator().next();
                         actualQuery = (Document) actualQuery.get("$query");
                     }
-
-                    return mongoBackend.handleCommand(query.getChannel(), query.getDatabaseName(), command, actualQuery);
+                    return mongoBackend.handleCommandAsync(query.getChannel(),
+                        query.getDatabaseName(),
+                        command,
+                        actualQuery);
             }
         }
 
-        throw new MongoServerException("unknown collection: " + collectionName);
+        return FutureUtils.failedFuture(new MongoServerException("unknown collection: " + collectionName));
     }
-
 
 }

--- a/core/src/test/java/de/bwaldvogel/mongo/wire/MongoDatabaseHandlerTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/wire/MongoDatabaseHandlerTest.java
@@ -1,20 +1,29 @@
 package de.bwaldvogel.mongo.wire;
 
-import static de.bwaldvogel.mongo.TestUtils.json;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 
 import de.bwaldvogel.mongo.MongoBackend;
 import de.bwaldvogel.mongo.bson.Document;
+import de.bwaldvogel.mongo.wire.message.MessageHeader;
+import de.bwaldvogel.mongo.wire.message.MongoGetMore;
+import de.bwaldvogel.mongo.wire.message.MongoMessage;
 import de.bwaldvogel.mongo.wire.message.MongoQuery;
+import de.bwaldvogel.mongo.wire.message.MongoReply;
 import io.netty.channel.Channel;
+
+import static de.bwaldvogel.mongo.TestUtils.json;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class MongoDatabaseHandlerTest {
 
     @Test
-    void testWrappedCommand() {
+    void testWrappedCommand() throws Exception {
         final MongoBackend backend = mock(MongoBackend.class);
         final Channel channel = mock(Channel.class);
 
@@ -24,13 +33,13 @@ public class MongoDatabaseHandlerTest {
 
         final MongoDatabaseHandler handler = new MongoDatabaseHandler(backend, null);
 
-        handler.handleCommand(query);
+        handler.handleCommandAsync(query);
 
-        verify(backend).handleCommand(channel, "dbName", "count", subQueryDoc);
+        verify(backend).handleCommandAsync(channel, "dbName", "count", subQueryDoc);
     }
 
     @Test
-    void testNonWrappedCommand() {
+    void testNonWrappedCommand() throws Exception {
         final MongoBackend backend = mock(MongoBackend.class);
         final Channel channel = mock(Channel.class);
 
@@ -39,8 +48,133 @@ public class MongoDatabaseHandlerTest {
 
         final MongoDatabaseHandler handler = new MongoDatabaseHandler(backend, null);
 
-        handler.handleCommand(query);
+        handler.handleCommandAsync(query);
 
-        verify(backend).handleCommand(channel, "dbName", "count", queryDoc);
+        verify(backend).handleCommandAsync(channel, "dbName", "count", queryDoc);
+    }
+
+    @Test
+    void testHandleQueryUnknownCollection() throws Exception {
+        final MongoBackend backend = mock(MongoBackend.class);
+        when(backend.handleQueryAsync(any())).thenCallRealMethod();
+
+        final Channel channel = mock(Channel.class);
+
+        final MessageHeader header = new MessageHeader(0, 0);
+        final MongoQuery query = new MongoQuery(channel, header, "dbName.$cmd.unknown", 0, 0, null, null);
+
+        final MongoDatabaseHandler handler = new MongoDatabaseHandler(backend, null);
+
+        MongoReply responseMongoReply = handler.handleQueryAsync(query).toCompletableFuture().get();
+
+        assertThat(responseMongoReply).isNotNull();
+        List<Document> documents = responseMongoReply.getDocuments();
+        assertThat(documents).isNotEmpty();
+        Document doc = documents.get(0);
+        assertThat(doc).isNotNull();
+        assertThat(doc.get("$err")).isEqualTo("unknown collection: $cmd.unknown");
+        assertThat(doc.get("errmsg")).isEqualTo("unknown collection: $cmd.unknown");
+        assertThat(doc.get("ok")).isEqualTo(0);
+    }
+
+    @Test
+    void testHandleQueryCommandUnknownError() throws Exception {
+        final MongoBackend backend = mock(MongoBackend.class);
+        when(backend.handleCommandAsync(any(), any(), any(), any())).thenCallRealMethod();
+        when(backend.handleCommand(any(), any(), any(), any())).thenThrow(new RuntimeException("unexpected"));
+
+        final Channel channel = mock(Channel.class);
+
+        final MessageHeader header = new MessageHeader(0, 0);
+        final Document queryDoc = json("'$query': { 'count': 'collectionName' }, '$readPreference': { 'mode': 'secondaryPreferred' }");
+        final MongoQuery query = new MongoQuery(channel, header, "dbName.$cmd", 0, 0, queryDoc, null);
+
+        final MongoDatabaseHandler handler = new MongoDatabaseHandler(backend, null);
+
+        MongoReply responseMongoReply = handler.handleQueryAsync(query).toCompletableFuture().get();
+
+        assertThat(responseMongoReply).isNotNull();
+        List<Document> documents = responseMongoReply.getDocuments();
+        assertThat(documents).isNotEmpty();
+        Document doc = documents.get(0);
+        assertThat(doc).isNotNull();
+        assertThat(doc.get("$err")).isEqualTo("Unknown error: unexpected");
+        assertThat(doc.get("errmsg")).isEqualTo("Unknown error: unexpected");
+        assertThat(doc.get("ok")).isEqualTo(0);
+    }
+
+    @Test
+    void testHandleQueryUnknownError() throws Exception {
+        final MongoBackend backend = mock(MongoBackend.class);
+        when(backend.handleQueryAsync(any())).thenCallRealMethod();
+        when(backend.handleQuery(any())).thenThrow(new RuntimeException("unexpected"));
+
+        final Channel channel = mock(Channel.class);
+
+        final MessageHeader header = new MessageHeader(0, 0);
+        final MongoQuery query = new MongoQuery(channel, header, "dbName.find", 0, 0, null, null);
+
+        final MongoDatabaseHandler handler = new MongoDatabaseHandler(backend, null);
+
+        MongoReply responseMongoReply = handler.handleQueryAsync(query).toCompletableFuture().get();
+
+        assertThat(responseMongoReply).isNotNull();
+        List<Document> documents = responseMongoReply.getDocuments();
+        assertThat(documents).isNotEmpty();
+        Document doc = documents.get(0);
+        assertThat(doc).isNotNull();
+        assertThat(doc.get("$err")).isEqualTo("Unknown error: unexpected");
+        assertThat(doc.get("errmsg")).isEqualTo("Unknown error: unexpected");
+        assertThat(doc.get("ok")).isEqualTo(0);
+    }
+
+    @Test
+    void testHandleMessageUnknownError() throws Exception {
+        final MongoBackend backend = mock(MongoBackend.class);
+        when(backend.handleMessageAsync(any())).thenCallRealMethod();
+        when(backend.handleMessage(any())).thenThrow(new RuntimeException("unexpected"));
+
+        final Channel channel = mock(Channel.class);
+
+        final MessageHeader header = new MessageHeader(0, 0);
+
+        final MongoDatabaseHandler handler = new MongoDatabaseHandler(backend, null);
+
+        MongoMessage requestMessage = new MongoMessage(channel, header, new Document("key", "1"));
+
+        MongoMessage responseMessage = handler.handleMessageAsync(requestMessage).toCompletableFuture().get();
+
+        assertThat(responseMessage).isNotNull();
+        Document responseMessageDoc = responseMessage.getDocument();
+        assertThat(responseMessageDoc).isNotNull();
+        assertThat(responseMessageDoc.get("$err")).isEqualTo("Unknown error: unexpected");
+        assertThat(responseMessageDoc.get("errmsg")).isEqualTo("Unknown error: unexpected");
+        assertThat(responseMessageDoc.get("ok")).isEqualTo(0);
+    }
+
+    @Test
+    void testHandleGetMoreUnknownError() throws Exception {
+        final MongoBackend backend = mock(MongoBackend.class);
+        when(backend.handleGetMoreAsync(any())).thenCallRealMethod();
+        when(backend.handleGetMore(any())).thenThrow(new RuntimeException("unexpected"));
+
+        final Channel channel = mock(Channel.class);
+
+        final MessageHeader header = new MessageHeader(0, 0);
+
+        final MongoDatabaseHandler handler = new MongoDatabaseHandler(backend, null);
+
+        MongoGetMore requestGetMore = new MongoGetMore(channel, header, "collectionName", 5, 0);
+
+        MongoReply responseMongoReply = handler.handleGetMoreAsync(requestGetMore).toCompletableFuture().get();
+
+        assertThat(responseMongoReply).isNotNull();
+        List<Document> documents = responseMongoReply.getDocuments();
+        assertThat(documents).isNotEmpty();
+        Document doc = documents.get(0);
+        assertThat(doc).isNotNull();
+        assertThat(doc.get("$err")).isEqualTo("Unknown error: unexpected");
+        assertThat(doc.get("errmsg")).isEqualTo("Unknown error: unexpected");
+        assertThat(doc.get("ok")).isEqualTo(0);
     }
 }


### PR DESCRIPTION
**Overview:**

All operations are asynchronous in Netty. Currently, methods called in `MongoDatabaseHandler#channelRead0` are blocking, which caused threads parking and inefficiency. By adding the non-blocking asynchronous code, it would be much more efficient.

**Summary of changes:**

Add async support by wrapping synchronous calls with a helper class and return as `CompletionStage<T>`.

Changes should not affect any existing synchronous mechanism.

This is the initial change. Follow-up changes would be made based on this PR if approved.

Please feel free to comment, thanks!