### PR TITLE
Async support follow-up 1

### DIFF
--- a/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoBackendTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoBackendTest.java
@@ -1,11 +1,10 @@
 package de.bwaldvogel.mongo.backend;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-
+import java.net.InetSocketAddress;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -16,10 +15,19 @@ import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.exception.CursorNotFoundException;
 import de.bwaldvogel.mongo.wire.message.MongoGetMore;
 import de.bwaldvogel.mongo.wire.message.MongoKillCursors;
+import io.netty.channel.Channel;
+import org.mockito.Mockito;
+
+import static de.bwaldvogel.mongo.backend.AbstractMongoBackend.ADMIN_DB_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
 
 class AbstractMongoBackendTest {
 
     private MongoBackend backend;
+    private MongoBackend backendWithError;
     private CursorRegistry cursorRegistry;
 
     @BeforeEach
@@ -32,7 +40,28 @@ class AbstractMongoBackendTest {
 
             @Override
             protected MongoDatabase openOrCreateDatabase(String databaseName) {
+                MongoDatabase mockDatabase = Mockito.mock(AbstractMongoDatabase.class);
+
+                Document fakeResponse = new Document();
+                Utils.markOkay(fakeResponse);
+                fakeResponse.put("message", "fakeResponse");
+
+                when(mockDatabase.handleCommand(any(), any(), any(), any())).thenReturn(fakeResponse);
+
+                return mockDatabase;
+            }
+        };
+
+        backendWithError = new AbstractMongoBackend() {
+
+            @Override
+            protected MongoDatabase openOrCreateDatabase(String databaseName) {
                 return null;
+            }
+
+            @Override
+            public void dropDatabase(String database) {
+                throw new RuntimeException("unexpected");
             }
         };
     }
@@ -73,4 +102,56 @@ class AbstractMongoBackendTest {
         assertThat(cursorRegistry.getCursor(cursor2.getId())).isNotNull();
     }
 
+    @Test
+    void testHandleCommand() {
+        Channel channel = Mockito.mock(Channel.class);
+        when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.1.254", 27017));
+
+        Document response = backend.handleCommand(channel, null, "whatsmyuri", null);
+        assertThat(response).isNotNull();
+        assertThat(response.get("ok")).isEqualTo(1.0);
+        assertThat(response.get("you")).isEqualTo("127.0.1.254:27017");
+    }
+
+    @Test
+    void testHandleAdminCommand() {
+        Channel channel = Mockito.mock(Channel.class);
+
+        Document response = backend.handleCommand(channel, ADMIN_DB_NAME, "ping", null);
+        assertThat(response).isNotNull();
+        assertThat(response.get("ok")).isEqualTo(1.0);
+    }
+
+    @Test
+    void testMongoDatabaseHandleCommand() {
+        Channel channel = Mockito.mock(Channel.class);
+
+        Document response = backend.handleCommand(channel, "mockDatabase", "find", null);
+        assertThat(response).isNotNull();
+        assertThat(response.get("ok")).isEqualTo(1.0);
+        assertThat(response.get("message")).isEqualTo("fakeResponse");
+    }
+
+    @Test
+    void testHandleCommandAsyncDropDatabase() throws Exception {
+        Channel channel = Mockito.mock(Channel.class);
+
+        CompletionStage<Document> responseFuture = backend.handleCommandAsync(channel, "mockDatabase", "dropDatabase", null);
+        Document response = responseFuture.toCompletableFuture().get();
+        assertThat(response).isNotNull();
+        assertThat(response.get("ok")).isEqualTo(1.0);
+        assertThat(response.get("dropped")).isEqualTo("mockDatabase");
+    }
+
+    @Test
+    void testHandleCommandAsyncDropDatabaseError() throws Exception {
+        Channel channel = Mockito.mock(Channel.class);
+
+        CompletionStage<Document> responseFuture = backendWithError.handleCommandAsync(channel, "mockDatabase", "dropDatabase", null);
+        Document response = responseFuture.toCompletableFuture().get();
+        assertThat(response).isNotNull();
+        assertThat(response.get("ok")).isEqualTo(0.0);
+        assertThat(response.get("dropped")).isEqualTo("mockDatabase");
+        assertThat(response.get("errmsg")).isEqualTo("unexpected");
+    }
 }

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoDatabaseTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoDatabaseTest.java
@@ -1,0 +1,104 @@
+package de.bwaldvogel.mongo.backend;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import de.bwaldvogel.mongo.MongoCollection;
+import de.bwaldvogel.mongo.bson.Document;
+import io.netty.channel.Channel;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.when;
+
+class AbstractMongoDatabaseTest {
+
+    private AbstractMongoDatabase<Object> database;
+    private CursorRegistry cursorRegistry;
+
+    @BeforeEach
+    public void setup() {
+        cursorRegistry = Mockito.mock(CursorRegistry.class);
+
+        database = new AbstractMongoDatabase<Object>("testdb", cursorRegistry) {
+
+            @Override
+            protected long getFileSize() {
+                return 0;
+            }
+
+            @Override
+            protected long getStorageSize() {
+                return 0;
+            }
+
+            @Override
+            protected Index<Object> openOrCreateUniqueIndex(String collectionName, String indexName, List<IndexKey> keys, boolean sparse) {
+                return null;
+            }
+
+            @Override
+            protected MongoCollection<Object> openOrCreateCollection(String collectionName, CollectionOptions options) {
+                MongoCollection<Object> collection = (MongoCollection<Object>) Mockito.mock(MongoCollection.class);
+                when(collection.getCollectionName()).thenReturn("mockCollection");
+
+                QueryResult queryResult = new QueryResult(Collections.singletonList(new Document("_id", 1)));
+
+                when(collection.handleQuery(any(), anyInt(), anyInt(), anyInt(), any()))
+                    .thenReturn(queryResult);
+
+                when(collection.handleQueryAsync(any(), anyInt(), anyInt(), anyInt(), any()))
+                    .thenCallRealMethod();
+
+                return collection;
+            }
+        };
+
+        database.initializeNamespacesAndIndexes();
+    }
+
+    @Test
+    void testHandleCommandAsyncFindReturnEmpty() throws Exception {
+        Channel channel = Mockito.mock(Channel.class);
+
+        Document query = new Document();
+        query.put("find", "testCollection");
+
+        CompletionStage<Document> responseFuture = database.handleCommandAsync(channel, "find", query, null);
+        Document response = responseFuture.toCompletableFuture().get();
+
+        assertThat(response).isNotNull();
+        assertThat(response.get("ok")).isEqualTo(1.0);
+    }
+
+    @Test
+    void testHandleCommandAsyncFindReturnSomething() throws Exception {
+        Channel channel = Mockito.mock(Channel.class);
+
+        Document query = new Document();
+        query.put("find", "mockCollection");
+
+        CompletionStage<Document> responseFuture = database.handleCommandAsync(channel, "find", query, null);
+        Document response = responseFuture.toCompletableFuture().get();
+
+        assertThat(response).isNotNull();
+        assertThat(response.get("ok")).isEqualTo(1.0);
+
+        Document cursor = (Document) response.get("cursor");
+        assertThat(cursor).isNotNull();
+
+        List<Document> firstBatch = (List<Document>) cursor.get("firstBatch");
+        assertThat(firstBatch).isNotNull();
+        assertThat(firstBatch).hasSize(1);
+
+        Document doc = firstBatch.get(0);
+        assertThat(doc).isNotNull();
+        assertThat(doc.get("_id")).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Follow up changes after PR #147.

**Summary of changes**

Made changes in `AbstractMongoBackend` and `AbstractMongoDatabase` such that they are calling the corresponding async methods in the pipelines.

Commands updated:
- `dropDatabase` in `AbstractMongoBackend`
- `find` in `AbstractMongoDatabase`
