### PR TITLE
Fix last and first accumulator for missing values

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/accumulator/FirstAccumulator.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/accumulator/FirstAccumulator.java
@@ -13,8 +13,12 @@ public class FirstAccumulator extends Accumulator {
 
     @Override
     public void aggregate(Object value) {
-        if (first && !(value instanceof Missing)) {
-            firstValue = value;
+        if (first) {
+            if (!(value instanceof Missing)) {
+                firstValue = value;
+            } else {
+                firstValue = null;
+            }
             first = false;
         }
     }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/accumulator/LastAccumulator.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/accumulator/LastAccumulator.java
@@ -14,6 +14,8 @@ public class LastAccumulator extends Accumulator {
     public void aggregate(Object value) {
         if (!(value instanceof Missing)) {
             lastValue = value;
+        } else {
+            lastValue = null;
         }
     }
 

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractAggregationTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractAggregationTest.java
@@ -931,6 +931,36 @@ public abstract class AbstractAggregationTest extends AbstractTest {
     }
 
     @Test
+    void testAggregateWithGroupingAndFirstMissing() throws Exception {
+        Document sort = json("$sort: {_id: 1}");
+        Document group = json("$group: {_id: '$group', first: { $first: '$field1' }}");
+        List<Document> pipeline = Arrays.asList(sort, group);
+
+        collection.insertOne(json("_id: 1, group: 1"));
+        collection.insertOne(json("_id: 2, group: 1, field1: 'abc'"));
+
+        assertThat(collection.aggregate(pipeline))
+                .containsExactly(
+                        json("_id: 1, first: null")
+                );
+    }
+
+    @Test
+    void testAggregateWithGroupingAndLastMissing() throws Exception {
+        Document sort = json("$sort: {_id: 1}");
+        Document group = json("$group: {_id: '$group', last: { $last: '$field1' }}");
+        List<Document> pipeline = Arrays.asList(sort, group);
+
+        collection.insertOne(json("_id: 1, group: 1, field1: 'abc'"));
+        collection.insertOne(json("_id: 2, group: 1"));
+
+        assertThat(collection.aggregate(pipeline))
+                .containsExactly(
+                        json("_id: 1, last: null")
+                );
+    }
+
+    @Test
     void testAggregateWithPush() throws Exception {
         List<Document> pipeline = jsonList("$group: {_id: null, a: {$push: '$a'}, b: {$push: {v: '$b'}}, c: {$push: '$c'}}");
 


### PR DESCRIPTION
Hello,

this PR fixes an issue with $first and $last aggregations. According to mongo documentation, $last and $first return null, if the operand is missing. The test cases added by this PR verify this, without the changes the tests run within the RealMongoAggregationTest, but not in MemoryBackendAggregationTest.

fixes #170