### PR TITLE
Allow arrayElemAt to respect nested queries

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/Expression.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/aggregation/Expression.java
@@ -163,7 +163,9 @@ public enum Expression implements ExpressionTraits {
             if (index < 0 || index >= collection.size()) {
                 return null;
             } else {
-                return collection.get(index);
+                Object ret = collection.get(index);
+                if(Missing.isNullOrMissing(ret)) return null;
+                return  ret;
             }
         }
     },
@@ -1754,7 +1756,7 @@ public enum Expression implements ExpressionTraits {
                 String variable = value.substring(1);
                 throw new MongoServerError(17276, "Use of undefined variable: " + variable);
             }
-            return Utils.getSubdocumentValue(document, value);
+            return Utils.getSubdocumentValueCollectionAware(document, value);
         } else if (expression instanceof Document) {
             return evaluateDocumentExpression((Document) expression, document);
         } else {

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/ExpressionTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/ExpressionTest.java
@@ -147,6 +147,15 @@ public class ExpressionTest {
         assertThat(Expression.evaluate(json("$arrayElemAt: ['$items', '$pos']"), json("items: ['a', 'b', 'c'], pos: -1"))).isEqualTo("c");
         assertThat(Expression.evaluate(json("$arrayElemAt: ['$items', '$pos']"), json(""))).isNull();
 
+        assertThat(Expression.evaluate(json("$arrayElemAt: ['$items.foo', -1]"), json("items: [{foo: 'bar'}, {foo: 'bas'}, {foo: 'bat'}]")))
+            .isEqualTo("bat");
+        assertThat(Expression.evaluate(json("$arrayElemAt: ['$items.foo', 0]"), json("items: [{foo: {ping: 'pong'}}, {foo: 'bas'}, {foo: 'bat'}]")))
+            .isEqualTo(json("ping: 'pong'"));
+        assertThat(Expression.evaluate(json("$arrayElemAt: ['$items.foo', 1]"), json("items: [1, {foo: 11}, 3]")))
+            .isEqualTo(11);
+        assertThat(Expression.evaluate(json("$arrayElemAt: ['$items.foo', 0]"), json("items: [1, {foo: 11}, 3]")))
+            .isNull();
+
         assertThatExceptionOfType(MongoServerError.class)
             .isThrownBy(() -> Expression.evaluate(json("$arrayElemAt: null"), json("")))
             .withMessage("[Error 16020] Expression $arrayElemAt takes exactly 2 arguments. 1 were passed in.");
@@ -1244,7 +1253,7 @@ public class ExpressionTest {
         assertThat(Expression.evaluate(json("$strLenBytes: '$a'"), json("a: 'value'"))).isEqualTo(5);
         assertThat(Expression.evaluate(json("$strLenBytes: 'cafétéria'"), json(""))).isEqualTo(11);
         assertThat(Expression.evaluate(json("$strLenBytes: '$a'"), json("a: '$€λA'"))).isEqualTo(7);
-        assertThat(Expression.evaluate(json("$strLenBytes: '寿司'"), json(""))).isEqualTo(6);
+        assertThat(Expression.evaluate(json("$strLenBytes: '\u5BFF\u53F8'"), json(""))).isEqualTo(6);
 
         assertThatExceptionOfType(MongoServerError.class)
             .isThrownBy(() -> Expression.evaluate(json("$strLenBytes: null"), json("")))
@@ -1265,7 +1274,7 @@ public class ExpressionTest {
         assertThat(Expression.evaluate(json("$strLenCP: '$a'"), json("a: 'value'"))).isEqualTo(5);
         assertThat(Expression.evaluate(json("$strLenCP: 'cafétéria'"), json(""))).isEqualTo(9);
         assertThat(Expression.evaluate(json("$strLenCP: '$a'"), json("a: '$€λA'"))).isEqualTo(4);
-        assertThat(Expression.evaluate(json("$strLenCP: '寿司'"), json(""))).isEqualTo(2);
+        assertThat(Expression.evaluate(json("$strLenCP: '\u5BFF\u53F8'"), json(""))).isEqualTo(2);
 
         assertThatExceptionOfType(MongoServerError.class)
             .isThrownBy(() -> Expression.evaluate(json("$strLenCP: null"), json("")))

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/ProjectStageTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/aggregation/stage/ProjectStageTest.java
@@ -23,7 +23,11 @@ public class ProjectStageTest {
         assertThat(project(json("_id: 1, a: 10, b: 20, c: -30"), json("x: {$abs: '$c'}"))).isEqualTo(json("_id: 1, x: 30"));
         assertThat(project(json("_id: 1, c: -30"), json("x: {y: {$abs: '$c'}}"))).isEqualTo(json("_id: 1, x: {y: 30}"));
         assertThat(project(json("_id: 1, b: 2 c: -30"), json("x: {y: {$multiply: ['$b', {$abs: '$c'}]}}"))).isEqualTo(json("_id: 1, x: {y: 60}"));
+        assertThat(project(json("a: [1,2,3]"), json("b: {$arrayElemAt: ['$a', 1]}"))).isEqualTo(json("b: 2"));
+        assertThat(project(json("a: [{foo: 'bar'}, {foo: 'bas'}, {foo: 'bat'}]"), json("b: {$arrayElemAt: ['$a.foo', 1]}")))
+            .isEqualTo(json("b: 'bas'"));
     }
+
 
     @Test
     void testProject_withNestedExclusion() throws Exception {


### PR DESCRIPTION
Simple change to allow `$arrayElemAt` to work on things like `$foo.bar`.

Does this look ok?