### PR TITLE
Extract mongo version to interface

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
@@ -38,6 +38,6 @@ public interface MongoBackend {
 
     MongoDatabase resolveDatabase(String database);
 
-    MongoBackend version(ServerVersion version);
+    MongoBackend version(MongoVersion version);
 
 }

--- a/core/src/main/java/de/bwaldvogel/mongo/MongoVersion.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoVersion.java
@@ -1,0 +1,13 @@
+package de.bwaldvogel.mongo;
+
+import java.util.List;
+
+public interface MongoVersion {
+
+    List<Integer> getVersionArray();
+
+    String toVersionString();
+
+    int getWireVersion();
+
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/ServerVersion.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/ServerVersion.java
@@ -6,7 +6,7 @@ import java.util.List;
 
 import de.bwaldvogel.mongo.backend.Utils;
 
-public enum ServerVersion {
+public enum ServerVersion implements MongoVersion {
     MONGO_3_6(Arrays.asList(3, 6, 0), 6);
 
     private final List<Integer> versionArray;

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoBackend.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import de.bwaldvogel.mongo.MongoBackend;
 import de.bwaldvogel.mongo.MongoCollection;
 import de.bwaldvogel.mongo.MongoDatabase;
+import de.bwaldvogel.mongo.MongoVersion;
 import de.bwaldvogel.mongo.ServerVersion;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.exception.MongoServerException;
@@ -49,7 +50,7 @@ public abstract class AbstractMongoBackend implements MongoBackend {
 
     private final Map<String, MongoDatabase> databases = new ConcurrentHashMap<>();
 
-    private ServerVersion version = ServerVersion.MONGO_3_6;
+    private MongoVersion version = ServerVersion.MONGO_3_6;
 
     private final Clock clock;
     private final Instant started;
@@ -432,7 +433,7 @@ public abstract class AbstractMongoBackend implements MongoBackend {
     }
 
     @Override
-    public MongoBackend version(ServerVersion version) {
+    public MongoBackend version(MongoVersion version) {
         this.version = version;
         return this;
     }

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/ReadOnlyProxy.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/ReadOnlyProxy.java
@@ -9,7 +9,7 @@ import java.util.Set;
 
 import de.bwaldvogel.mongo.MongoBackend;
 import de.bwaldvogel.mongo.MongoDatabase;
-import de.bwaldvogel.mongo.ServerVersion;
+import de.bwaldvogel.mongo.MongoVersion;
 import de.bwaldvogel.mongo.backend.aggregation.Aggregation;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.exception.MongoServerException;
@@ -106,7 +106,7 @@ public class ReadOnlyProxy implements MongoBackend {
     }
 
     @Override
-    public MongoBackend version(ServerVersion version) {
+    public MongoBackend version(MongoVersion version) {
         throw new ReadOnlyException("not supported");
     }
 


### PR DESCRIPTION
This feature gives users the ability to supply their own version from their in-memory backends. Useful for testing runtime version safety checks.