### PR TITLE
Fix: serverStatus command to execute in both admin and non-admin db(s)

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoBackend.java
@@ -197,8 +197,6 @@ public abstract class AbstractMongoBackend implements MongoBackend {
             return handleGetCmdLineOpts();
         } else if (command.equalsIgnoreCase("getFreeMonitoringStatus")) {
             return handleGetFreeMonitoringStatus();
-        } else if (command.equalsIgnoreCase("serverStatus")) {
-            return getServerStatus();
         } else if (command.equalsIgnoreCase("endSessions")) {
             log.debug("endSessions on admin database");
             return successResponse();
@@ -331,6 +329,8 @@ public abstract class AbstractMongoBackend implements MongoBackend {
             return handleKillCursors(query);
         } else if (command.equalsIgnoreCase("ping")) {
             return successResponse();
+        } else if (command.equalsIgnoreCase("serverStatus")) {
+            return getServerStatus();
         } else if (databaseName.equals(ADMIN_DB_NAME)) {
             return handleAdminCommand(command, query);
         }

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
@@ -2468,7 +2468,11 @@ public abstract class AbstractBackendTest extends AbstractTest {
 
     @Test
     public void testServerStatus() throws Exception {
-        Document serverStatus = runCommand("serverStatus");
+        verifyServerStatus(runCommand("serverStatus"));
+        verifyServerStatus(getDatabase().runCommand(json("serverStatus:1")));
+    }
+
+    private void verifyServerStatus(Document serverStatus) {
         assertThat(serverStatus.getDouble("ok")).isEqualTo(1);
         assertThat(serverStatus.get("uptime")).isInstanceOf(Number.class);
         assertThat(serverStatus.get("uptimeMillis")).isInstanceOf(Long.class);

--- a/test-common/src/test/java/de/bwaldvogel/mongo/RealMongoBackendTest.java
+++ b/test-common/src/test/java/de/bwaldvogel/mongo/RealMongoBackendTest.java
@@ -115,7 +115,11 @@ public class RealMongoBackendTest extends AbstractBackendTest {
     @Test
     @Override
     public void testServerStatus() throws Exception {
-        Document serverStatus = runCommand("serverStatus");
+        verifyServerStatus(runCommand("serverStatus"));
+        verifyServerStatus(db.runCommand(json("serverStatus:1")));
+    }
+
+    private void verifyServerStatus(Document serverStatus) {
         assertThat(serverStatus.getDouble("ok")).isEqualTo(1);
         assertThat(serverStatus.get("uptime")).isInstanceOf(Number.class);
         assertThat(serverStatus.get("uptimeMillis")).isInstanceOf(Long.class);


### PR DESCRIPTION
This change has been made to correct the behaviour of serverStatus command. Should return a success response executing from both admin and non-admin databases.