### PR TITLE
feat: convert string commands to enum

### DIFF
--- a/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoBackend.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.util.Collection;
 import java.util.List;
 
+import de.bwaldvogel.mongo.backend.DatabaseCommand;
 import de.bwaldvogel.mongo.backend.QueryResult;
 import de.bwaldvogel.mongo.bson.Document;
 import de.bwaldvogel.mongo.wire.message.MongoMessage;
@@ -14,7 +15,7 @@ public interface MongoBackend {
 
     void handleClose(Channel channel);
 
-    Document handleCommand(Channel channel, String database, String command, Document query);
+    Document handleCommand(Channel channel, String database, DatabaseCommand command, Document query);
 
     QueryResult handleQuery(MongoQuery query);
 

--- a/core/src/main/java/de/bwaldvogel/mongo/MongoDatabase.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/MongoDatabase.java
@@ -1,6 +1,7 @@
 package de.bwaldvogel.mongo;
 
 import de.bwaldvogel.mongo.backend.CollectionOptions;
+import de.bwaldvogel.mongo.backend.DatabaseCommand;
 import de.bwaldvogel.mongo.backend.DatabaseResolver;
 import de.bwaldvogel.mongo.backend.QueryResult;
 import de.bwaldvogel.mongo.bson.Document;
@@ -14,7 +15,7 @@ public interface MongoDatabase {
 
     void handleClose(Channel channel);
 
-    Document handleCommand(Channel channel, String command, Document query, DatabaseResolver databaseResolver, Oplog oplog);
+    Document handleCommand(Channel channel, DatabaseCommand command, Document query, DatabaseResolver databaseResolver, Oplog oplog);
 
     QueryResult handleQuery(MongoQuery query);
 

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoBackend.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -152,57 +151,69 @@ public abstract class AbstractMongoBackend implements MongoBackend {
         return response;
     }
 
-    private Document handleAdminCommand(String command, Document query) {
-        if (command.equalsIgnoreCase("listdatabases")) {
-            List<Document> databases = listDatabaseNames().stream()
-                .sorted()
-                .map(databaseName -> {
-                    MongoDatabase database = openOrCreateDatabase(databaseName);
-                    Document dbObj = new Document("name", database.getDatabaseName());
-                    dbObj.put("empty", Boolean.valueOf(database.isEmpty()));
-                    return dbObj;
-                })
-                .collect(Collectors.toList());
-            Document response = new Document();
-            response.put("databases", databases);
-            Utils.markOkay(response);
-            return response;
-        } else if (command.equalsIgnoreCase("find")) {
-            String collectionName = (String) query.get(command);
-            if (collectionName.equals("$cmd.sys.inprog")) {
-                return Utils.firstBatchCursorResponse(collectionName, new Document("inprog", Collections.emptyList()));
-            } else {
-                throw new NoSuchCommandException(new Document(command, collectionName).toString());
+    private Document handleAdminCommand(DatabaseCommand command, Document query) {
+        switch (command.getCommand()) {
+            case LIST_DATABASES: {
+                List<Document> databases = listDatabaseNames().stream()
+                    .sorted()
+                    .map(databaseName -> {
+                        MongoDatabase database = openOrCreateDatabase(databaseName);
+                        Document dbObj = new Document("name", database.getDatabaseName());
+                        dbObj.put("empty", Boolean.valueOf(database.isEmpty()));
+                        return dbObj;
+                    })
+                    .toList();
+                Document response = new Document();
+                response.put("databases", databases);
+                Utils.markOkay(response);
+                return response;
             }
-        } else if (command.equalsIgnoreCase("replSetGetStatus")) {
-            throw new NoReplicationEnabledException();
-        } else if (command.equalsIgnoreCase("getLog")) {
-            final Object argument = query.get(command);
-            return getLog(argument == null ? null : argument.toString());
-        } else if (command.equalsIgnoreCase("renameCollection")) {
-            return handleRenameCollection(command, query);
-        } else if (command.equalsIgnoreCase("getLastError")) {
-            log.debug("getLastError on admin database");
-            return successResponse();
-        } else if (command.equalsIgnoreCase("connectionStatus")) {
-            Document response = new Document();
-            response.append("authInfo", new Document()
-                .append("authenticatedUsers", Collections.emptyList())
-                .append("authenticatedUserRoles", Collections.emptyList())
-            );
-            Utils.markOkay(response);
-            return response;
-        } else if (command.equalsIgnoreCase("hostInfo")) {
-            return handleHostInfo();
-        } else if (command.equalsIgnoreCase("getCmdLineOpts")) {
-            return handleGetCmdLineOpts();
-        } else if (command.equalsIgnoreCase("getFreeMonitoringStatus")) {
-            return handleGetFreeMonitoringStatus();
-        } else if (command.equalsIgnoreCase("endSessions")) {
-            log.debug("endSessions on admin database");
-            return successResponse();
-        } else {
-            throw new NoSuchCommandException(command);
+            case FIND: {
+                String collectionName = query.get(command.getQueryValue()).toString();
+                if (collectionName.equals("$cmd.sys.inprog")) {
+                    return Utils.firstBatchCursorResponse(collectionName, new Document("inprog", Collections.emptyList()));
+                } else {
+                    throw new NoSuchCommandException(new Document(command.getQueryValue(), collectionName).toString());
+                }
+            }
+            case REPL_SET_GET_STATUS: {
+                throw new NoReplicationEnabledException();
+            }
+            case GET_LOG: {
+                final Object argument = query.get(command.getQueryValue());
+                return getLog(argument == null ? null : argument.toString());
+            }
+            case RENAME_COLLECTION: {
+                return handleRenameCollection(command.getQueryValue(), query);
+            }
+            case GET_LAST_ERROR: {
+                log.debug("getLastError on admin database");
+                return successResponse();
+            }
+            case CONNECTION_STATUS: {
+                Document response = new Document();
+                response.append("authInfo", new Document()
+                    .append("authenticatedUsers", Collections.emptyList())
+                    .append("authenticatedUserRoles", Collections.emptyList())
+                );
+                Utils.markOkay(response);
+                return response;
+            }
+            case HOST_INFO: {
+                return handleHostInfo();
+            }
+            case GET_CMD_LINE_OPTS: {
+                return handleGetCmdLineOpts();
+            }
+            case GET_FREE_MONITORING_STATUS: {
+                return handleGetFreeMonitoringStatus();
+            }
+            case END_SESSIONS: {
+                log.debug("endSessions on admin database");
+                return successResponse();
+            }
+            default:
+                throw new NoSuchCommandException(command.getQueryValue());
         }
     }
 
@@ -299,45 +310,46 @@ public abstract class AbstractMongoBackend implements MongoBackend {
     protected abstract MongoDatabase openOrCreateDatabase(String databaseName);
 
     @Override
-    public Document handleCommand(Channel channel, String databaseName, String command, Document query) {
-        if (command.equalsIgnoreCase("whatsmyuri")) {
-            Document response = new Document();
-            InetSocketAddress remoteAddress = (InetSocketAddress) channel.remoteAddress();
-            response.put("you", remoteAddress.getAddress().getHostAddress() + ":" + remoteAddress.getPort());
-            Utils.markOkay(response);
-            return response;
-        } else if (command.equalsIgnoreCase("ismaster")) {
-            Document response = new Document("ismaster", Boolean.TRUE);
-            response.put("maxBsonObjectSize", Integer.valueOf(BsonConstants.MAX_BSON_OBJECT_SIZE));
-            response.put("maxWriteBatchSize", Integer.valueOf(MongoWireProtocolHandler.MAX_WRITE_BATCH_SIZE));
-            response.put("maxMessageSizeBytes", Integer.valueOf(MongoWireProtocolHandler.MAX_MESSAGE_SIZE_BYTES));
-            response.put("maxWireVersion", Integer.valueOf(version.getWireVersion()));
-            response.put("minWireVersion", Integer.valueOf(0));
-            response.put("localTime", Instant.now(clock));
-            Utils.markOkay(response);
-            return response;
-        } else if (command.equalsIgnoreCase("buildinfo")) {
-            Document response = new Document("version", version.toVersionString());
-            response.put("versionArray", version.getVersionArray());
-            response.put("maxBsonObjectSize", Integer.valueOf(BsonConstants.MAX_BSON_OBJECT_SIZE));
-            Utils.markOkay(response);
-            return response;
-        } else if (command.equalsIgnoreCase("dropDatabase")) {
-            return handleDropDatabase(databaseName);
-        } else if (command.equalsIgnoreCase("getMore")) {
-            return handleGetMore(databaseName, command, query);
-        } else if (command.equalsIgnoreCase("killCursors")) {
-            return handleKillCursors(query);
-        } else if (command.equalsIgnoreCase("ping")) {
-            return successResponse();
-        } else if (command.equalsIgnoreCase("serverStatus")) {
-            return getServerStatus();
-        } else if (databaseName.equals(ADMIN_DB_NAME)) {
-            return handleAdminCommand(command, query);
-        }
-
-        MongoDatabase mongoDatabase = resolveDatabase(databaseName);
-        return mongoDatabase.handleCommand(channel, command, query, this::resolveDatabase, oplog);
+    public Document handleCommand(Channel channel, String databaseName, DatabaseCommand command, Document query) {
+        return switch (command.getCommand()) {
+            case WHATS_MY_URI -> {
+                Document response = new Document();
+                InetSocketAddress remoteAddress = (InetSocketAddress) channel.remoteAddress();
+                response.put("you", remoteAddress.getAddress().getHostAddress() + ":" + remoteAddress.getPort());
+                Utils.markOkay(response);
+                yield response;
+            }
+            case IS_MASTER -> {
+                Document response = new Document("ismaster", Boolean.TRUE);
+                response.put("maxBsonObjectSize", Integer.valueOf(BsonConstants.MAX_BSON_OBJECT_SIZE));
+                response.put("maxWriteBatchSize", Integer.valueOf(MongoWireProtocolHandler.MAX_WRITE_BATCH_SIZE));
+                response.put("maxMessageSizeBytes", Integer.valueOf(MongoWireProtocolHandler.MAX_MESSAGE_SIZE_BYTES));
+                response.put("maxWireVersion", Integer.valueOf(version.getWireVersion()));
+                response.put("minWireVersion", Integer.valueOf(0));
+                response.put("localTime", Instant.now(clock));
+                Utils.markOkay(response);
+                yield response;
+            }
+            case BUILD_INFO -> {
+                Document response = new Document("version", version.toVersionString());
+                response.put("versionArray", version.getVersionArray());
+                response.put("maxBsonObjectSize", Integer.valueOf(BsonConstants.MAX_BSON_OBJECT_SIZE));
+                Utils.markOkay(response);
+                yield response;
+            }
+            case DROP_DATABASE -> handleDropDatabase(databaseName);
+            case GET_MORE -> handleGetMore(databaseName, command.getQueryValue(), query);
+            case KILL_CURSORS -> handleKillCursors(query);
+            case PING -> successResponse();
+            case SERVER_STATUS -> getServerStatus();
+            default -> {
+                if (databaseName.equals(ADMIN_DB_NAME)) {
+                    yield handleAdminCommand(command, query);
+                }
+                MongoDatabase mongoDatabase = resolveDatabase(databaseName);
+                yield mongoDatabase.handleCommand(channel, command, query, this::resolveDatabase, oplog);
+            }
+        };
     }
 
     @Override
@@ -409,7 +421,7 @@ public abstract class AbstractMongoBackend implements MongoBackend {
         Channel channel = message.getChannel();
         String databaseName = message.getDatabaseName();
         Document query = message.getDocument();
-        String command = query.keySet().iterator().next();
+        DatabaseCommand command = DatabaseCommand.of(query.keySet().iterator().next());
         return handleCommand(channel, databaseName, command, query);
     }
 

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoBackend.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoBackend.java
@@ -152,46 +152,29 @@ public abstract class AbstractMongoBackend implements MongoBackend {
     }
 
     private Document handleAdminCommand(DatabaseCommand command, Document query) {
-        switch (command.getCommand()) {
-            case LIST_DATABASES: {
-                return handleListDatabases();
-            }
-            case FIND: {
-                return handleFind(command, query);
-            }
-            case REPL_SET_GET_STATUS: {
-                throw new NoReplicationEnabledException();
-            }
-            case GET_LOG: {
+        return switch (command.getCommand()) {
+            case LIST_DATABASES -> handleListDatabases();
+            case FIND -> handleFind(command, query);
+            case REPL_SET_GET_STATUS -> throw new NoReplicationEnabledException();
+            case GET_LOG -> {
                 final Object argument = query.get(command.getQueryValue());
-                return getLog(argument == null ? null : argument.toString());
+                yield getLog(argument == null ? null : argument.toString());
             }
-            case RENAME_COLLECTION: {
-                return handleRenameCollection(command.getQueryValue(), query);
-            }
-            case GET_LAST_ERROR: {
+            case RENAME_COLLECTION -> handleRenameCollection(command.getQueryValue(), query);
+            case GET_LAST_ERROR -> {
                 log.debug("getLastError on admin database");
-                return successResponse();
+                yield successResponse();
             }
-            case CONNECTION_STATUS: {
-                return handleConnectionStatus();
-            }
-            case HOST_INFO: {
-                return handleHostInfo();
-            }
-            case GET_CMD_LINE_OPTS: {
-                return handleGetCmdLineOpts();
-            }
-            case GET_FREE_MONITORING_STATUS: {
-                return handleGetFreeMonitoringStatus();
-            }
-            case END_SESSIONS: {
+            case CONNECTION_STATUS -> handleConnectionStatus();
+            case HOST_INFO -> handleHostInfo();
+            case GET_CMD_LINE_OPTS -> handleGetCmdLineOpts();
+            case GET_FREE_MONITORING_STATUS -> handleGetFreeMonitoringStatus();
+            case END_SESSIONS -> {
                 log.debug("endSessions on admin database");
-                return successResponse();
+                yield successResponse();
             }
-            default:
-                throw new NoSuchCommandException(command.getQueryValue());
-        }
+            default -> throw new NoSuchCommandException(command.getQueryValue());
+        };
     }
 
     private Document handleListDatabases() {

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoDatabase.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/AbstractMongoDatabase.java
@@ -123,45 +123,13 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
             case CREATE_INDEXES -> commandCreateIndexes(query, query.get(commandName).toString());
             case COUNT -> commandCount(commandName, query);
             case AGGREGATE -> commandAggregate(commandName, query, databaseResolver, oplog);
-            case DISTINCT -> {
-                MongoCollection<P> collection = resolveCollection(commandName, query);
-                if (collection == null) {
-                    Document response = new Document("values", Collections.emptyList());
-                    Utils.markOkay(response);
-                    yield response;
-                } else {
-                    yield collection.handleDistinct(query);
-                }
-            }
+            case DISTINCT -> commandDistinct(commandName, query);
             case DROP -> commandDrop(commandName, query, oplog);
             case DROP_INDEXES -> commandDropIndexes(commandName, query);
             case DB_STATS -> commandDatabaseStats();
-            case COLL_STATS -> {
-                MongoCollection<P> collection = resolveCollection(commandName, query);
-                if (collection == null) {
-                    Document emptyStats = new Document()
-                        .append("count", 0)
-                        .append("size", 0);
-                    Utils.markOkay(emptyStats);
-                    yield emptyStats;
-                } else {
-                    yield collection.getStats();
-                }
-            }
-            case VALIDATE -> {
-                MongoCollection<P> collection = resolveCollection(commandName, query);
-                if (collection == null) {
-                    String collectionName = query.get(commandName).toString();
-                    String fullCollectionName = getDatabaseName() + "." + collectionName;
-                    throw new MongoServerError(26, "NamespaceNotFound", "Collection '" + fullCollectionName + "' does not exist to validate.");
-                }
-                yield collection.validate();
-            }
-            case FIND_AND_MODIFY -> {
-                String collectionName = query.get(commandName).toString();
-                MongoCollection<P> collection = resolveOrCreateCollection(collectionName);
-                yield collection.findAndModify(query);
-            }
+            case COLL_STATS -> commandCollStats(commandName, query);
+            case VALIDATE -> commandValidate(commandName, query);
+            case FIND_AND_MODIFY -> findAndModify(commandName, query);
             case LIST_COLLECTIONS -> listCollections();
             case LIST_INDEXES -> listIndexes(query.get(commandName).toString());
             case TRIGGER_INTERNAL_EXCEPTION -> throw new NullPointerException("For testing purposes");
@@ -501,6 +469,35 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
         return response;
     }
 
+    private Document commandCollStats(String commandName, Document query) {
+        MongoCollection<P> collection = resolveCollection(commandName, query);
+        if (collection == null) {
+            Document emptyStats = new Document()
+                .append("count", 0)
+                .append("size", 0);
+            Utils.markOkay(emptyStats);
+            return emptyStats;
+        } else {
+            return collection.getStats();
+        }
+    }
+
+    private Document commandValidate(String commandName, Document query) {
+        MongoCollection<P> collection = resolveCollection(commandName, query);
+        if (collection == null) {
+            String collectionName = query.get(commandName).toString();
+            String fullCollectionName = getDatabaseName() + "." + collectionName;
+            throw new MongoServerError(26, "NamespaceNotFound", "Collection '" + fullCollectionName + "' does not exist to validate.");
+        }
+        return collection.validate();
+    }
+
+    private Document findAndModify(String commandName, Document query) {
+        String collectionName = query.get(commandName).toString();
+        MongoCollection<P> collection = resolveOrCreateCollection(collectionName);
+        return collection.findAndModify(query);
+    }
+
     protected abstract long getFileSize();
 
     protected abstract long getStorageSize();
@@ -609,6 +606,17 @@ public abstract class AbstractMongoDatabase<P> implements MongoDatabase {
 
         Aggregation aggregation = getAggregation(pipeline, query, databaseResolver, collection, oplog);
         return Utils.firstBatchCursorResponse(getFullCollectionNamespace(collectionName), aggregation.computeResult());
+    }
+
+    private Document commandDistinct(String commandName, Document query) {
+        MongoCollection<P> collection = resolveCollection(commandName, query);
+        if (collection == null) {
+            Document response = new Document("values", Collections.emptyList());
+            Utils.markOkay(response);
+            return response;
+        } else {
+            return collection.handleDistinct(query);
+        }
     }
 
     private Aggregation getAggregation(List<Document> pipeline, Document query, DatabaseResolver databaseResolver,

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/Command.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/Command.java
@@ -1,0 +1,85 @@
+package de.bwaldvogel.mongo.backend;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum Command {
+    // User
+    AGGREGATE("aggregate"),
+    COUNT("count"),
+    DISTINCT("distinct"),
+
+    // Query and write operation
+    DELETE("delete"),
+    FIND("find"),
+    FIND_AND_MODIFY("findAndModify"),
+    GET_LAST_ERROR("getLastError"), // removed in 5.1
+    GET_MORE("getMore"),
+    INSERT("insert"),
+    RESET_ERROR("resetError"),
+    UPDATE("update"),
+
+    // Replication
+    IS_MASTER("isMaster"),
+    REPL_SET_GET_STATUS("replSetGetStatus"),
+
+    // Session
+    END_SESSIONS("endSessions"),
+
+    //  Administration
+    CREATE("create"),
+    CREATE_INDEXES("createIndexes"),
+    DROP("drop"),
+    DROP_DATABASE("dropDatabase"),
+    DROP_INDEXES("dropIndexes"),
+    KILL_CURSORS("killCursors"),
+    LIST_COLLECTIONS("listCollections"),
+    LIST_DATABASES("listDatabases"),
+    LIST_INDEXES("listIndexes"),
+    RENAME_COLLECTION("renameCollection"),
+
+    // Diagnostic
+    BUILD_INFO("buildInfo"),
+    COLL_STATS("collStats"),
+    CONNECTION_STATUS("connectionStatus"),
+    DB_STATS("dbStats"),
+    GET_CMD_LINE_OPTS("getCmdLineOpts"),
+    GET_LOG("getLog"),
+    HOST_INFO("hostInfo"),
+    PING("ping"),
+    SERVER_STATUS("serverStatus"),
+    VALIDATE("validate"),
+    WHATS_MY_URI("whatsmyuri"),
+
+    // Monitoring
+    GET_FREE_MONITORING_STATUS("getFreeMonitoringStatus"),
+
+    // internal use
+    TRIGGER_INTERNAL_EXCEPTION("triggerInternalException"),
+    UNKNOWN("unknown");
+
+    private final String name;
+    private static final Map<String, Command> LOOKUP;
+
+    static {
+        LOOKUP = Arrays.stream(Command.values())
+            .collect(Collectors.toMap(
+                c -> c.name.toLowerCase(),
+                Function.identity()
+            ));
+    }
+
+    Command(String name) {
+        this.name = name;
+    }
+
+    String getName() {
+        return name;
+    }
+
+    public static Command parseString(String commandName) {
+        return LOOKUP.getOrDefault(commandName.toLowerCase(), UNKNOWN);
+    }
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/DatabaseCommand.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/DatabaseCommand.java
@@ -1,0 +1,50 @@
+package de.bwaldvogel.mongo.backend;
+
+import java.util.Objects;
+
+public class DatabaseCommand {
+    private final Command command;
+    private final String queryValue;
+
+    private DatabaseCommand(String queryCommand) {
+        this.command = Command.parseString(queryCommand);
+        this.queryValue = queryCommand;
+    }
+
+    private DatabaseCommand(Command command) {
+        this.command = command;
+        this.queryValue = command.getName();
+    }
+
+    public static DatabaseCommand of(String queryValue) {
+        return new DatabaseCommand(queryValue);
+    }
+
+    public static DatabaseCommand of(Command command) {
+        return new DatabaseCommand(command);
+    }
+
+    public Command getCommand() {
+        return command;
+    }
+
+    public String getQueryValue() {
+        return queryValue;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (!(obj instanceof DatabaseCommand other)){
+            return false;
+        }
+        return command == other.command;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(command);
+    }
+}

--- a/core/src/main/java/de/bwaldvogel/mongo/backend/ReadOnlyProxy.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/backend/ReadOnlyProxy.java
@@ -1,5 +1,17 @@
 package de.bwaldvogel.mongo.backend;
 
+import static de.bwaldvogel.mongo.backend.Command.BUILD_INFO;
+import static de.bwaldvogel.mongo.backend.Command.COLL_STATS;
+import static de.bwaldvogel.mongo.backend.Command.COUNT;
+import static de.bwaldvogel.mongo.backend.Command.DB_STATS;
+import static de.bwaldvogel.mongo.backend.Command.DISTINCT;
+import static de.bwaldvogel.mongo.backend.Command.FIND;
+import static de.bwaldvogel.mongo.backend.Command.GET_LAST_ERROR;
+import static de.bwaldvogel.mongo.backend.Command.GET_MORE;
+import static de.bwaldvogel.mongo.backend.Command.IS_MASTER;
+import static de.bwaldvogel.mongo.backend.Command.LIST_DATABASES;
+import static de.bwaldvogel.mongo.backend.Command.SERVER_STATUS;
+
 import java.time.Clock;
 import java.util.Collection;
 import java.util.List;
@@ -18,18 +30,18 @@ import io.netty.channel.Channel;
 
 public class ReadOnlyProxy implements MongoBackend {
 
-    private static final Set<String> allowedCommands = Set.of(
-        "ismaster",
-        "find",
-        "listdatabases",
-        "count",
-        "dbstats",
-        "distinct",
-        "collstats",
-        "serverstatus",
-        "buildinfo",
-        "getlasterror",
-        "getmore"
+    private static final Set<Command> allowedCommands = Set.of(
+        IS_MASTER,
+        FIND,
+        LIST_DATABASES,
+        COUNT,
+        DB_STATS,
+        DISTINCT,
+        COLL_STATS,
+        SERVER_STATUS,
+        BUILD_INFO,
+        GET_LAST_ERROR,
+        GET_MORE
     );
 
     private final MongoBackend backend;
@@ -54,19 +66,19 @@ public class ReadOnlyProxy implements MongoBackend {
     }
 
     @Override
-    public Document handleCommand(Channel channel, String database, String command, Document query) {
-        if (isAllowed(command, query)) {
+    public Document handleCommand(Channel channel, String database, DatabaseCommand command, Document query) {
+        if (isAllowed(command.getCommand(), query)) {
             return backend.handleCommand(channel, database, command, query);
         }
-        throw new NoSuchCommandException(command);
+        throw new NoSuchCommandException(command.getQueryValue());
     }
 
-    private static boolean isAllowed(String command, Document query) {
-        if (allowedCommands.contains(command.toLowerCase())) {
+    private static boolean isAllowed(Command command, Document query) {
+        if (allowedCommands.contains(command)) {
             return true;
         }
 
-        if (command.equalsIgnoreCase("aggregate")) {
+        if (command == Command.AGGREGATE) {
             List<Document> pipeline = Aggregation.parse(query.get("pipeline"));
             Aggregation aggregation = Aggregation.fromPipeline(pipeline, null, null, null, null);
             if (aggregation.isModifying()) {
@@ -82,7 +94,7 @@ public class ReadOnlyProxy implements MongoBackend {
     public Document handleMessage(MongoMessage message) {
         Document document = message.getDocument();
         String command = document.keySet().iterator().next().toLowerCase();
-        if (isAllowed(command, document)) {
+        if (isAllowed(Command.parseString(command), document)) {
             return backend.handleMessage(message);
         }
         throw new NoSuchCommandException(command);

--- a/core/src/main/java/de/bwaldvogel/mongo/wire/MongoDatabaseHandler.java
+++ b/core/src/main/java/de/bwaldvogel/mongo/wire/MongoDatabaseHandler.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import de.bwaldvogel.mongo.MongoBackend;
+import de.bwaldvogel.mongo.backend.DatabaseCommand;
 import de.bwaldvogel.mongo.backend.QueryResult;
 import de.bwaldvogel.mongo.backend.Utils;
 import de.bwaldvogel.mongo.bson.Document;
@@ -127,12 +128,12 @@ public class MongoDatabaseHandler extends SimpleChannelInboundHandler<ClientRequ
 
         } else if ("$cmd".equals(collectionName)) {
             String command = query.getQuery().keySet().iterator().next();
-
-            switch (command) {
-                case "serverStatus":
+            DatabaseCommand cmd = DatabaseCommand.of(command);
+            switch (cmd.getCommand()) {
+                case SERVER_STATUS:
                     return mongoBackend.getServerStatus();
 
-                case "ping":
+                case PING:
                     Document response = new Document();
                     Utils.markOkay(response);
                     return response;
@@ -141,9 +142,10 @@ public class MongoDatabaseHandler extends SimpleChannelInboundHandler<ClientRequ
                     Document actualQuery = query.getQuery();
                     if ("$query".equals(command)) {
                         command = ((Document) query.getQuery().get("$query")).keySet().iterator().next();
+                        cmd = DatabaseCommand.of(command);
                         actualQuery = (Document) actualQuery.get("$query");
                     }
-                    return mongoBackend.handleCommand(query.getChannel(), query.getDatabaseName(), command, actualQuery);
+                    return mongoBackend.handleCommand(query.getChannel(), query.getDatabaseName(), cmd, actualQuery);
             }
         }
 

--- a/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoBackendTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/backend/AbstractMongoBackendTest.java
@@ -58,7 +58,7 @@ class AbstractMongoBackendTest {
         Channel channel = Mockito.mock(Channel.class);
         when(channel.remoteAddress()).thenReturn(new InetSocketAddress("127.0.1.254", 27017));
 
-        Document response = backend.handleCommand(channel, null, "whatsmyuri", null);
+        Document response = backend.handleCommand(channel, null, DatabaseCommand.of(Command.WHATS_MY_URI), null);
         assertThat(response).isNotNull();
         assertThat(response.get("ok")).isEqualTo(1.0);
         assertThat(response.get("you")).isEqualTo("127.0.1.254:27017");
@@ -68,7 +68,7 @@ class AbstractMongoBackendTest {
     void testHandleAdminCommand() {
         Channel channel = Mockito.mock(Channel.class);
 
-        Document response = backend.handleCommand(channel, ADMIN_DB_NAME, "ping", null);
+        Document response = backend.handleCommand(channel, ADMIN_DB_NAME, DatabaseCommand.of(Command.PING), null);
         assertThat(response).isNotNull();
         assertThat(response.get("ok")).isEqualTo(1.0);
     }
@@ -77,7 +77,7 @@ class AbstractMongoBackendTest {
     void testMongoDatabaseHandleCommand() {
         Channel channel = Mockito.mock(Channel.class);
 
-        Document response = backend.handleCommand(channel, "mockDatabase", "find", null);
+        Document response = backend.handleCommand(channel, "mockDatabase", DatabaseCommand.of(Command.FIND), null);
         assertThat(response).isNotNull();
         assertThat(response.get("ok")).isEqualTo(1.0);
         assertThat(response.get("message")).isEqualTo("fakeResponse");

--- a/core/src/test/java/de/bwaldvogel/mongo/wire/MongoDatabaseHandlerTest.java
+++ b/core/src/test/java/de/bwaldvogel/mongo/wire/MongoDatabaseHandlerTest.java
@@ -7,6 +7,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.bwaldvogel.mongo.backend.Command;
+
+import de.bwaldvogel.mongo.backend.DatabaseCommand;
+
 import org.junit.jupiter.api.Test;
 
 import de.bwaldvogel.mongo.MongoBackend;
@@ -31,7 +35,7 @@ class MongoDatabaseHandlerTest {
 
         handler.handleCommand(query);
 
-        verify(backend).handleCommand(channel, "dbName", "count", subQueryDoc);
+        verify(backend).handleCommand(channel, "dbName", DatabaseCommand.of(Command.COUNT), subQueryDoc);
     }
 
     @Test
@@ -46,7 +50,7 @@ class MongoDatabaseHandlerTest {
 
         handler.handleCommand(query);
 
-        verify(backend).handleCommand(channel, "dbName", "count", queryDoc);
+        verify(backend).handleCommand(channel, "dbName", DatabaseCommand.of(Command.COUNT), queryDoc);
     }
 
     @Test

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractBackendTest.java
@@ -2468,7 +2468,7 @@ public abstract class AbstractBackendTest extends AbstractTest {
 
     @Test
     public void testServerStatus() {
-        verifyServerStatus(runCommand("serverStatus"));
+        verifyServerStatus(runCommand(Command.SERVER_STATUS));
         verifyServerStatus(getDatabase().runCommand(json("serverStatus:1")));
     }
 
@@ -2492,7 +2492,7 @@ public abstract class AbstractBackendTest extends AbstractTest {
         try (MongoCursor<Document> cursor1 = collection.find().batchSize(10).cursor();
              MongoCursor<Document> cursor2 = collection.find().batchSize(10).cursor()) {
             log.debug("Opened {} and {}", cursor1.getServerCursor(), cursor2.getServerCursor());
-            Document serverStatus = runCommand("serverStatus");
+            Document serverStatus = runCommand(Command.SERVER_STATUS);
             assertThat(serverStatus.getDouble("ok")).isEqualTo(1);
 
             Document metrics = serverStatus.get("metrics", Document.class);
@@ -2507,7 +2507,7 @@ public abstract class AbstractBackendTest extends AbstractTest {
 
     @Test
     void testPing() {
-        assertThat(runCommand("ping").getDouble("ok")).isEqualTo(1.0);
+        assertThat(runCommand(Command.PING).getDouble("ok")).isEqualTo(1.0);
         assertThat(runCommand(json("ping: true")).getDouble("ok")).isEqualTo(1.0);
         assertThat(runCommand(json("ping: 2.0")).getDouble("ok")).isEqualTo(1.0);
         assertThat(getDatabase().runCommand(json("ping: true")).getDouble("ok")).isEqualTo(1.0);
@@ -2516,7 +2516,7 @@ public abstract class AbstractBackendTest extends AbstractTest {
     @Test
     void testReplSetGetStatus() {
         assertThatExceptionOfType(MongoCommandException.class)
-            .isThrownBy(() -> runCommand("replSetGetStatus"))
+            .isThrownBy(() -> runCommand(Command.REPL_SET_GET_STATUS))
             .withMessageStartingWith("Command execution failed on MongoDB server with error 76 (NoReplicationEnabled): 'not running with --replSet'");
     }
 
@@ -3795,7 +3795,7 @@ public abstract class AbstractBackendTest extends AbstractTest {
 
     @Test
     void testIsMaster() {
-        Document isMaster = runCommand("isMaster");
+        Document isMaster = runCommand(Command.IS_MASTER);
         assertThat(isMaster.getBoolean("ismaster")).isTrue();
         assertThat(isMaster.getDate("localTime")).isInstanceOf(Date.class);
         Integer maxBsonObjectSize = isMaster.getInteger("maxBsonObjectSize");
@@ -5230,7 +5230,7 @@ public abstract class AbstractBackendTest extends AbstractTest {
     void testGetLastError() {
         collection.insertOne(json("_id: 1"));
 
-        Document actual = db.runCommand(json("getlasterror: 1"));
+        Document actual = db.runCommand(json("getLastError: 1"));
         assertThat(actual.get("n")).isEqualTo(0);
         assertThat(actual).containsKey("err");
         assertThat(actual.get("err")).isNull();
@@ -5240,7 +5240,7 @@ public abstract class AbstractBackendTest extends AbstractTest {
             .isThrownBy(() -> collection.insertOne(json("_id: 1.0")))
             .withMessageContaining("E11000 duplicate key error collection: testdb.testcoll index: _id_ dup key: { _id: 1.0 }");
 
-        Document lastError = db.runCommand(json("getlasterror: 1"));
+        Document lastError = db.runCommand(json("getLastError: 1"));
         assertThat(lastError.get("code")).isEqualTo(11000);
         assertThat(lastError.getString("err")).contains("duplicate key");
         assertThat(lastError.getString("codeName")).isEqualTo("DuplicateKey");
@@ -5255,10 +5255,10 @@ public abstract class AbstractBackendTest extends AbstractTest {
             .isThrownBy(() -> collection.insertOne(json("_id: 1.0")))
             .withMessageContaining("duplicate key error collection: testdb.testcoll index: _id_ dup key: { _id: 1.0 }");
 
-        assertThat(db.runCommand(json("reseterror: 1")))
+        assertThat(db.runCommand(json("resetError: 1")))
             .isEqualTo(json("ok: 1.0"));
 
-        assertThat(db.runCommand(json("getlasterror: 1")))
+        assertThat(db.runCommand(json("getLastError: 1")))
             .containsAllEntriesOf(json("err: null, n: 0, ok: 1.0"));
     }
 
@@ -6638,27 +6638,27 @@ public abstract class AbstractBackendTest extends AbstractTest {
 
     @Test
     void testConnectionStatus() {
-        Document result = runCommand("connectionStatus");
+        Document result = runCommand(Command.CONNECTION_STATUS);
         assertThat(result).isEqualTo(json("ok: 1.0, authInfo: {authenticatedUsers: [], authenticatedUserRoles: []}"));
     }
 
     @Test
     void testHostInfo() {
-        Document result = runCommand("hostInfo");
+        Document result = runCommand(Command.HOST_INFO);
         assertThat(result.get("ok")).isEqualTo(1.0);
         assertThat(result).containsKeys("os", "system", "extra");
     }
 
     @Test
     void testGetCmdLineOpts() {
-        Document result = runCommand("getCmdLineOpts");
+        Document result = runCommand(Command.GET_CMD_LINE_OPTS);
         assertThat(result.get("ok")).isEqualTo(1.0);
         assertThat(result).containsOnlyKeys("ok", "argv", "parsed");
     }
 
     @Test
     void testGetFreeMonitoringStatus() {
-        Document result = runCommand("getFreeMonitoringStatus");
+        Document result = runCommand(Command.GET_FREE_MONITORING_STATUS);
         assertThat(result).isEqualTo(json("ok: 1.0, state: 'disabled', debug: {state: 'undecided'}," +
             " message: 'Free monitoring is deprecated, refer to \\'debug\\' field for actual status'"));
     }

--- a/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractTest.java
+++ b/test-common/src/main/java/de/bwaldvogel/mongo/backend/AbstractTest.java
@@ -200,8 +200,8 @@ public abstract class AbstractTest {
         return databaseNames;
     }
 
-    protected Document runCommand(String commandName) {
-        return runCommand(new Document(commandName, 1));
+    protected Document runCommand(Command commandName) {
+        return runCommand(new Document(commandName.getName(), 1));
     }
 
     protected Document runCommand(Document command) {
@@ -213,7 +213,7 @@ public abstract class AbstractTest {
     }
 
     protected long getNumberOfOpenCursors() {
-        Document serverStatus = runCommand("serverStatus");
+        Document serverStatus = runCommand(Command.SERVER_STATUS);
         assertThat(serverStatus.getDouble("ok")).isEqualTo(1);
         Document metrics = serverStatus.get("metrics", Document.class);
         Document cursorMetrics = metrics.get("cursor", Document.class);

--- a/test-common/src/test/java/de/bwaldvogel/mongo/RealMongoBackendTest.java
+++ b/test-common/src/test/java/de/bwaldvogel/mongo/RealMongoBackendTest.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.Date;
 
+import de.bwaldvogel.mongo.backend.Command;
+
 import org.bson.Document;
 import org.junit.jupiter.api.Assumptions;
 import org.junit.jupiter.api.BeforeEach;
@@ -115,8 +117,8 @@ public class RealMongoBackendTest extends AbstractBackendTest {
     @Test
     @Override
     public void testServerStatus() {
-        verifyServerStatus(runCommand("serverStatus"));
-        verifyServerStatus(db.runCommand(json("serverStatus:1")));
+        verifyServerStatus(runCommand(Command.SERVER_STATUS));
+        verifyServerStatus(db.runCommand(json("serverStatus: 1")));
     }
 
     private void verifyServerStatus(Document serverStatus) {


### PR DESCRIPTION
I hope you are appreciating this refactoring with strong typing.

I have modeled the supported/implemented commands in a enumeration and wrapped it in a value object so we can retrieve the original query command string because of the case insensitivity.

Some benefits:

- compile-time safety - typos are caught at compile time
- documentation - enum serves as documentation of all supported commands
- performance - single toLowerCase() with HashMap lookup
